### PR TITLE
Undo automatic escaping of % signs

### DIFF
--- a/openshift/config.go
+++ b/openshift/config.go
@@ -1,7 +1,6 @@
 package openshift
 
 import (
-	"bytes"
 	"fmt"
 	"github.com/ghodss/yaml"
 	"github.com/opendevstack/tailor/cli"
@@ -63,11 +62,8 @@ func (c *Config) Process() {
 		return
 	}
 
-	// The % symbol has a special meaning in YAML, it needs to be doubled.
-	escapedRaw := bytes.Replace(c.Raw, []byte("%"), []byte("%%"), -1)
-
 	var f interface{}
-	yaml.Unmarshal(escapedRaw, &f)
+	yaml.Unmarshal(c.Raw, &f)
 
 	m := f.(map[string]interface{})
 

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -1,7 +1,6 @@
 package openshift
 
 import (
-	"bytes"
 	"fmt"
 	"github.com/opendevstack/tailor/cli"
 	"io/ioutil"
@@ -169,9 +168,7 @@ func ocApply(change *Change, action string) error {
 	name := change.Name
 	config := change.DesiredState
 	fmt.Println(action, kind, name)
-	b := []byte(config)
-	unescapedRaw := bytes.Replace(b, []byte("%%"), []byte("%"), -1)
-	ioutil.WriteFile(".PROCESSED_TEMPLATE", unescapedRaw, 0644)
+	ioutil.WriteFile(".PROCESSED_TEMPLATE", []byte(config), 0644)
 
 	args := []string{"apply", "--filename=" + ".PROCESSED_TEMPLATE"}
 	cmd := cli.ExecOcCmd(args)


### PR DESCRIPTION
It was a bad idea to automatically escape % signs. This causes all sorts
of issues (e.g. if %-sign is used in a string which is intended for the
underlying app) and is based on the assumption that the YML author does
not know about the special meaning of %-signs.

For now, we will just stop escaping automatically. This might lead to
weird diffs (which was the original motivation to have this), but at
least it is safe and does not cause side-effects.

Closes #4.