### PR TITLE
Support configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased
 
-* Use compact help template (which allows to show help for just one command).
-* Fix wrong export target when just one resource is specified (#11).
-* Percent signs (%) are not automatically encoded (duplicated) to prevent issues (#4).
+* [Feature] `Tailorfile` support
+* [Task] Use compact help template (which allows to show help for just one command).
+* [Fix] Fix wrong export target when just one resource is specified (#11).
+* [Fix] Percent signs (%) are not automatically encoded (duplicated) to prevent issues (#4).
 
 ## 0.5.1 (2018-07-12)
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ Another complication arises when provisioning a DeploymentConfig referencing a n
 
 `tailor` needs access to a resource in order to be able to compare it. This means that to properly compare all resources, the user of the OpenShift session that `tailor` makes use of needs to be admin. If you are not admin, `tailor` will fail as it cannot compare some resources. To prevent this from happening, exclude the resource types (e.g. `rolebinding` and `serviceaccount`) that you do not have access to.
 
+### Tailorfile
+
+Since specifying all params correctly can be daunting, and it isn't easy to share how `tailor` should be invoked, `tailor` supports setting params via a `Tailorfile`. This is simply a line-delimited file with flags, e.g.:
+```
+template-dir foo
+param-dir bar
+param OC=cd
+param BAZ=QUX
+
+bc,is,dc,svc
+```
+
 ### Command Completion
 
 BASH/ZSH completion is available. Add this into `.bash_profile` or equivalent:

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -19,7 +19,7 @@ type Options struct {
 	Selector  string
 }
 
-var options *Options
+var verbose bool
 
 var PrintGreenf func(format string, a ...interface{})
 var PrintBluef func(format string, a ...interface{})
@@ -32,42 +32,27 @@ func init() {
 	PrintBluef = color.New(color.FgBlue).PrintfFunc()
 	PrintYellowf = color.New(color.FgYellow).PrintfFunc()
 	PrintRedf = color.New(color.FgRed).PrintfFunc()
-	options = &Options{
-		Verbose:   false,
-		Namespace: "",
-		Selector:  "",
-	}
-}
-
-func SetOptions(verbose bool, namespace string, selector string) {
-	options = &Options{
-		Verbose:   verbose,
-		Namespace: namespace,
-		Selector:  selector,
-	}
+	verbose = false
 }
 
 func GetOcNamespace() (string, error) {
-	if len(options.Namespace) > 0 {
-		return options.Namespace, nil
-	}
 	cmd := ExecPlainOcCmd([]string{"project", "--short"})
 	n, err := cmd.CombinedOutput()
 	return strings.TrimSpace(string(n)), err
 }
 
 func VerboseMsg(messages ...string) {
-	if options.Verbose {
+	if verbose {
 		PrintBluef("--> %s\n", strings.Join(messages, " "))
 	}
 }
 
-func ExecOcCmd(args []string) *exec.Cmd {
-	if len(options.Namespace) > 0 {
-		args = append(args, "--namespace="+options.Namespace)
+func ExecOcCmd(args []string, namespace string, selector string) *exec.Cmd {
+	if len(namespace) > 0 {
+		args = append(args, "--namespace="+namespace)
 	}
-	if len(options.Selector) > 0 {
-		args = append(args, "--selector="+options.Selector)
+	if len(selector) > 0 {
+		args = append(args, "--selector="+selector)
 	}
 	return ExecPlainOcCmd(args)
 }

--- a/cli/options.go
+++ b/cli/options.go
@@ -1,0 +1,229 @@
+package cli
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+type GlobalOptions struct {
+	Verbose        bool
+	NonInteractive bool
+	File           string
+	Namespace      string
+	Selector       string
+	TemplateDirs   []string
+	ParamDirs      []string
+	PublicKeyDir   string
+	PrivateKey     string
+	Passphrase     string
+}
+
+type CompareOptions struct {
+	*GlobalOptions
+	Labels                  string
+	Params                  []string
+	ParamFile               string
+	IgnoreUnknownParameters bool
+	UpsertOnly              bool
+	Resource                string
+}
+
+type ExportOptions struct {
+	*GlobalOptions
+	Resource string
+}
+
+func GetFileFlags(filename string) (map[string]string, error) {
+	fileFlags := make(map[string]string)
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		if filename == "Tailorfile" {
+			VerboseMsg("No file '" + filename + "' found.")
+			return fileFlags, nil
+		}
+		return fileFlags, err
+	}
+
+	b, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return fileFlags, err
+	}
+	content := string(b)
+	text := strings.TrimSuffix(content, "\n")
+	lines := strings.Split(text, "\n")
+
+	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		pair := strings.SplitN(line, " ", 2)
+		if len(pair) == 2 {
+			key := pair[0]
+			value := pair[1]
+			if val, ok := fileFlags[key]; ok {
+				value = val + "," + value
+			}
+			fileFlags[key] = value
+		} else {
+			fileFlags["resource"] = pair[0]
+		}
+	}
+	return fileFlags, nil
+}
+
+func (o *GlobalOptions) UpdateWithFile(fileFlags map[string]string) {
+	if fileFlags["verbose"] == "true" {
+		o.Verbose = true
+	}
+	if fileFlags["non-interactive"] == "true" {
+		o.NonInteractive = true
+	}
+	if val, ok := fileFlags["namespace"]; ok {
+		o.Namespace = val
+	}
+	if val, ok := fileFlags["selector"]; ok {
+		o.Selector = val
+	}
+	if val, ok := fileFlags["template-dir"]; ok {
+		o.TemplateDirs = strings.Split(val, ",")
+	}
+	if val, ok := fileFlags["param-dir"]; ok {
+		o.ParamDirs = strings.Split(val, ",")
+	}
+	if val, ok := fileFlags["public-key-dir"]; ok {
+		o.PublicKeyDir = val
+	}
+	if val, ok := fileFlags["private-key"]; ok {
+		o.PrivateKey = val
+	}
+	if val, ok := fileFlags["passphrase"]; ok {
+		o.Passphrase = val
+	}
+}
+
+func (o *GlobalOptions) UpdateWithFlags(verboseFlag bool, nonInteractiveFlag bool, namespaceFlag string, selectorFlag string, templateDirFlag []string, paramDirFlag []string, publicKeyDirFlag string, privateKeyFlag string, passphraseFlag string) {
+	if verboseFlag {
+		o.Verbose = true
+	}
+	if nonInteractiveFlag {
+		o.NonInteractive = true
+	}
+	if len(namespaceFlag) > 0 {
+		o.Namespace = namespaceFlag
+	}
+	if len(selectorFlag) > 0 {
+		o.Selector = selectorFlag
+	}
+	if len(templateDirFlag) > 0 {
+		o.TemplateDirs = templateDirFlag
+	}
+	if len(paramDirFlag) > 0 {
+		o.ParamDirs = paramDirFlag
+	}
+	if len(publicKeyDirFlag) > 0 {
+		o.PublicKeyDir = publicKeyDirFlag
+	}
+	if len(privateKeyFlag) > 0 {
+		o.PrivateKey = privateKeyFlag
+	}
+	if len(passphraseFlag) > 0 {
+		o.Passphrase = passphraseFlag
+	}
+}
+
+func (o *GlobalOptions) Process() error {
+	verbose = o.Verbose
+	if len(o.Namespace) == 0 {
+		n, err := GetOcNamespace()
+		if err != nil {
+			return err
+		}
+		o.Namespace = n
+	}
+	return nil
+}
+
+func (o *CompareOptions) UpdateWithFile(fileFlags map[string]string) {
+	if val, ok := fileFlags["labels"]; ok {
+		o.Labels = val
+	}
+	if val, ok := fileFlags["param"]; ok {
+		o.Params = strings.Split(val, ",")
+	}
+	if val, ok := fileFlags["param-file"]; ok {
+		o.ParamFile = val
+	}
+	if fileFlags["ignore-unknown-parameters"] == "true" {
+		o.IgnoreUnknownParameters = true
+	}
+	if fileFlags["upsert-only"] == "true" {
+		o.UpsertOnly = true
+	}
+	if val, ok := fileFlags["resource"]; ok {
+		o.Resource = val
+	}
+}
+
+func (o *CompareOptions) UpdateWithFlags(labelsFlag string, paramFlag []string, paramFileFlag string, ignoreUnknownParametersFlag bool, upsertOnlyFlag bool, resourceArg string) {
+	if len(labelsFlag) > 0 {
+		o.Labels = labelsFlag
+	}
+	// Update / override params
+	if len(paramFlag) > 0 {
+		params := map[string]string{}
+		for _, setParam := range o.Params {
+			setPair := strings.SplitN(setParam, "=", 2)
+			key := setPair[0]
+			params[key] = setPair[1]
+			for _, newParam := range paramFlag {
+				newPair := strings.SplitN(newParam, "=", 2)
+				if key == newPair[0] {
+					params[key] = newPair[1]
+					break
+				}
+			}
+		}
+		o.Params = []string{}
+		for k, v := range params {
+			o.Params = append(o.Params, k+"="+v)
+		}
+		for _, v := range paramFlag {
+			pair := strings.SplitN(v, "=", 2)
+			if _, ok := params[pair[0]]; !ok {
+				o.Params = append(o.Params, v)
+			}
+		}
+	}
+	if len(paramFileFlag) > 0 {
+		o.ParamFile = paramFileFlag
+	}
+	if ignoreUnknownParametersFlag {
+		o.IgnoreUnknownParameters = true
+	}
+	if upsertOnlyFlag {
+		o.UpsertOnly = true
+	}
+	if len(resourceArg) > 0 {
+		o.Resource = resourceArg
+	}
+}
+
+func (o *CompareOptions) Process() error {
+	if (len(o.ParamDirs) > 1 || o.ParamDirs[0] != ".") && len(o.ParamFile) > 0 {
+		return errors.New("You cannot specify both --param-dir and --param-file.")
+	}
+	return nil
+}
+
+func (o *ExportOptions) UpdateWithFile(fileFlags map[string]string) {
+	if val, ok := fileFlags["resource"]; ok {
+		o.Resource = val
+	}
+}
+
+func (o *ExportOptions) UpdateWithFlags(resourceArg string) {
+	if len(resourceArg) > 0 {
+		o.Resource = resourceArg
+	}
+}

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-func ExportAsTemplate(filter *ResourceFilter, name string) ([]byte, error) {
+func ExportAsTemplate(filter *ResourceFilter, name string, exportOptions *cli.ExportOptions) ([]byte, error) {
 	ret := ""
 	args := []string{"export", "--as-template=" + name, "--output=yaml"}
 	if len(filter.Label) > 0 {
@@ -16,7 +16,11 @@ func ExportAsTemplate(filter *ResourceFilter, name string) ([]byte, error) {
 	}
 	target := filter.ConvertToTarget()
 	args = append(args, target)
-	cmd := cli.ExecOcCmd(args)
+	cmd := cli.ExecOcCmd(
+		args,
+		exportOptions.Namespace,
+		exportOptions.Selector,
+	)
 	out, err := cmd.CombinedOutput()
 
 	if err != nil {
@@ -34,11 +38,15 @@ func ExportAsTemplate(filter *ResourceFilter, name string) ([]byte, error) {
 	return out, err
 }
 
-func ExportResources(filter *ResourceFilter) ([]byte, error) {
+func ExportResources(filter *ResourceFilter, compareOptions *cli.CompareOptions) ([]byte, error) {
 	ret := ""
 	target := filter.ConvertToKinds()
 	args := []string{"export", target, "--output=yaml"}
-	cmd := cli.ExecOcCmd(args)
+	cmd := cli.ExecOcCmd(
+		args,
+		compareOptions.Namespace,
+		compareOptions.Selector,
+	)
 	out, err := cmd.CombinedOutput()
 
 	if err != nil {
@@ -56,7 +64,7 @@ func ExportResources(filter *ResourceFilter) ([]byte, error) {
 	return out, err
 }
 
-func ProcessTemplate(templateDir string, name string, paramDir string, label string, params []string, paramFile string, ignoreUnknownParameters bool, privateKey string, passphrase string) ([]byte, error) {
+func ProcessTemplate(templateDir string, name string, paramDir string, compareOptions *cli.CompareOptions) ([]byte, error) {
 	filename := templateDir + string(os.PathSeparator) + name
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
 		cli.VerboseMsg("Template '" + filename + "' does not exist.")
@@ -65,22 +73,20 @@ func ProcessTemplate(templateDir string, name string, paramDir string, label str
 
 	args := []string{"process", "--filename=" + filename, "--output=yaml"}
 
-	if len(label) > 0 {
-		args = append(args, "--labels="+label)
+	if len(compareOptions.Labels) > 0 {
+		args = append(args, "--labels="+compareOptions.Labels)
 	}
 
-	for _, param := range params {
+	for _, param := range compareOptions.Params {
 		args = append(args, "--param="+param)
 	}
 
-	actualParamFile := paramFile
+	actualParamFile := compareOptions.ParamFile
 	if len(actualParamFile) == 0 {
 		// Prefer <namespace> folder over current directory
 		if paramDir == "." {
-			if namespaceDir, err := cli.GetOcNamespace(); err == nil {
-				if _, err := os.Stat(namespaceDir); err == nil {
-					paramDir = namespaceDir
-				}
+			if _, err := os.Stat(compareOptions.Namespace); err == nil {
+				paramDir = compareOptions.Namespace
 			}
 		}
 
@@ -102,7 +108,7 @@ func ProcessTemplate(templateDir string, name string, paramDir string, label str
 		paramFileContent := string(b)
 		if strings.Contains(paramFileContent, ".ENC=") {
 			cli.VerboseMsg(actualParamFile, "needs to be decrypted")
-			readParams, err := NewParams(paramFileContent, privateKey, passphrase)
+			readParams, err := NewParams(paramFileContent, compareOptions.PrivateKey, compareOptions.Passphrase)
 			if err != nil {
 				return []byte{}, err
 			}
@@ -114,7 +120,7 @@ func ProcessTemplate(templateDir string, name string, paramDir string, label str
 		args = append(args, "--param-file="+tempParamFile)
 	}
 
-	if ignoreUnknownParameters {
+	if compareOptions.IgnoreUnknownParameters {
 		args = append(args, "--ignore-unknown-parameters=true")
 	}
 	cmd := cli.ExecPlainOcCmd(args)
@@ -130,28 +136,32 @@ func ProcessTemplate(templateDir string, name string, paramDir string, label str
 	return out, err
 }
 
-func UpdateRemote(changeset *Changeset) error {
+func UpdateRemote(changeset *Changeset, compareOptions *cli.CompareOptions) error {
 	for _, change := range changeset.Create {
-		ocApply(change, "Creating")
+		ocApply(change, "Creating", compareOptions)
 	}
 
 	for _, change := range changeset.Delete {
-		ocDelete(change)
+		ocDelete(change, compareOptions)
 	}
 
 	for _, change := range changeset.Update {
-		ocApply(change, "Updating")
+		ocApply(change, "Updating", compareOptions)
 	}
 
 	return nil
 }
 
-func ocDelete(change *Change) error {
+func ocDelete(change *Change, compareOptions *cli.CompareOptions) error {
 	kind := change.Kind
 	name := change.Name
 	fmt.Println("Deleting", kind, name)
 	args := []string{"delete", kind, name}
-	cmd := cli.ExecOcCmd(args)
+	cmd := cli.ExecOcCmd(
+		args,
+		compareOptions.Namespace,
+		compareOptions.Selector,
+	)
 	out, err := cmd.CombinedOutput()
 	if err == nil {
 		fmt.Printf("Removed '%s/%s'.\n", kind, name)
@@ -163,7 +173,7 @@ func ocDelete(change *Change) error {
 	return nil
 }
 
-func ocApply(change *Change, action string) error {
+func ocApply(change *Change, action string, compareOptions *cli.CompareOptions) error {
 	kind := change.Kind
 	name := change.Name
 	config := change.DesiredState
@@ -171,7 +181,11 @@ func ocApply(change *Change, action string) error {
 	ioutil.WriteFile(".PROCESSED_TEMPLATE", []byte(config), 0644)
 
 	args := []string{"apply", "--filename=" + ".PROCESSED_TEMPLATE"}
-	cmd := cli.ExecOcCmd(args)
+	cmd := cli.ExecOcCmd(
+		args,
+		compareOptions.Namespace,
+		compareOptions.Selector,
+	)
 	out, err := cmd.CombinedOutput()
 	if err == nil {
 		fmt.Printf("Applied processed '%s' template.\n", kind)


### PR DESCRIPTION
* Makes it easier to run Tailor as fewer (if any) options have to be
passed
* Allows sharing knowledge how Tailor should be used
* Contains a huge refactoring of the options, reducing the global state
and improving what has to be passed between methods

Closes #8.