### PR TITLE
Prevent original values in export

### DIFF
--- a/openshift/config.go
+++ b/openshift/config.go
@@ -43,7 +43,7 @@ func NewConfigFromTemplate(input []byte) *Config {
 		NameRegex:       "/objects/[0-9]+/metadata/name",
 		PointersToReset: make(map[string]string),
 	}
-	c.Process()
+	c.Process(false)
 	return c
 }
 
@@ -53,11 +53,11 @@ func NewConfigFromList(input []byte) *Config {
 		NameRegex:       "/items/[0-9]+/metadata/name",
 		PointersToReset: make(map[string]string),
 	}
-	c.Process()
+	c.Process(true)
 	return c
 }
 
-func (c *Config) Process() {
+func (c *Config) Process(setOriginalValues bool) {
 	if len(c.Raw) == 0 {
 		return
 	}
@@ -92,7 +92,10 @@ func (c *Config) Process() {
 		annotationValue, _, err := annotationPointer.Get(m)
 		if err == nil {
 			configPointer.Set(m, annotationValue)
-		} else {
+			if !setOriginalValues {
+				annotationPointer.Delete(m)
+			}
+		} else if setOriginalValues {
 			configValue, _, _ := configPointer.Get(m)
 			annotationPointer.Set(m, configValue)
 		}


### PR DESCRIPTION
If an original value is given in the exported resource on OpenShift,
we should copy its value into the config and delete the annotation.
If it is not given, we should not create it.

Comparing resources should remain unaffected.

Closes #3.
Closes #5.