### PR TITLE
Implement general handling of immutable fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [Feature] Implement general handling of immutable fields. Previously Tailor tried to modify the resource which resulted in an error, now it tries to recreate the resource. See #33.
 * [Feature] `--debug` flag, which contains debug information, reducing the amount of printed information when `--verbose` is given.
 
 ## 0.7.0 (2018-07-30)

--- a/openshift/changeset.go
+++ b/openshift/changeset.go
@@ -80,8 +80,23 @@ func NewChangeset(remoteResourceList, localResourceList *ResourceList, upsertOnl
 			}
 			if currentItemConfig == desiredItemConfig {
 				changeset.Noop = append(changeset.Noop, change)
-			} else {
+			} else if lItem.ImmutableFieldsEqual(rItem) {
 				changeset.Update = append(changeset.Update, change)
+			} else {
+				deleteChange := &Change{
+					Kind:         lItem.Kind,
+					Name:         lItem.Name,
+					CurrentState: currentItemConfig,
+					DesiredState: "",
+				}
+				changeset.Delete = append(changeset.Delete, deleteChange)
+				createChange := &Change{
+					Kind:         lItem.Kind,
+					Name:         lItem.Name,
+					CurrentState: "",
+					DesiredState: desiredItemConfig,
+				}
+				changeset.Create = append(changeset.Create, createChange)
 			}
 		}
 	}

--- a/openshift/item.go
+++ b/openshift/item.go
@@ -2,6 +2,15 @@ package openshift
 
 import (
 	"github.com/ghodss/yaml"
+	"github.com/xeipuuv/gojsonpointer"
+)
+
+var (
+	immuntableFields = map[string][]string{
+		"Route": []string{
+			"/spec/host",
+		},
+	}
 )
 
 type ResourceItem struct {
@@ -19,4 +28,24 @@ func (i *ResourceItem) FullName() string {
 func (i *ResourceItem) YamlConfig() string {
 	y, _ := yaml.Marshal(i.Config)
 	return string(y)
+}
+
+func (i *ResourceItem) GetField(pointer string) (string, error) {
+	p, _ := gojsonpointer.NewJsonPointer(pointer)
+	val, _, err := p.Get(i.Config)
+	return val.(string), err
+}
+
+func (i *ResourceItem) ImmutableFieldsEqual(other *ResourceItem) bool {
+	if val, ok := immuntableFields[i.Kind]; ok {
+		for _, f := range val {
+			itemVal, itemErr := i.GetField(f)
+			otherVal, otherErr := other.GetField(f)
+			if (itemErr == nil && otherErr != nil) || (itemErr != nil && otherErr == nil) || itemVal != otherVal {
+				return false
+			}
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
Previously Tailor tried to modify the resource which resulted in an error,
now it tries to recreate the resource. For now, only the route host
field is handled.

Closes #33.