### PR TITLE
Fix accidental image change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [Feature] Implement general handling of immutable fields. Previously Tailor tried to modify the resource which resulted in an error, now it tries to recreate the resource. See #33.
 * [Feature] `--debug` flag, which contains debug information, reducing the amount of printed information when `--verbose` is given.
+* [Fix] Image changed accidentally even other parts of the DeploymentConfig changed (#38).
 
 ## 0.7.0 (2018-07-30)
 

--- a/openshift/changeset.go
+++ b/openshift/changeset.go
@@ -24,10 +24,11 @@ type Changeset struct {
 }
 
 type Change struct {
-	Kind         string
-	Name         string
-	CurrentState string
-	DesiredState string
+	Kind          string
+	Name          string
+	CurrentState  string
+	DesiredState  string
+	DesiredConfig string
 }
 
 func NewChangeset(remoteResourceList, localResourceList *ResourceList, upsertOnly bool) *Changeset {
@@ -72,29 +73,39 @@ func NewChangeset(remoteResourceList, localResourceList *ResourceList, upsertOnl
 		if err == nil {
 			currentItemConfig := rItem.YamlConfig()
 			desiredItemConfig := lItem.YamlConfig()
-			change := &Change{
-				Kind:         lItem.Kind,
-				Name:         lItem.Name,
-				CurrentState: currentItemConfig,
-				DesiredState: desiredItemConfig,
-			}
 			if currentItemConfig == desiredItemConfig {
+				change := &Change{
+					Kind:          lItem.Kind,
+					Name:          lItem.Name,
+					CurrentState:  "",
+					DesiredState:  "",
+					DesiredConfig: "",
+				}
 				changeset.Noop = append(changeset.Noop, change)
 			} else if lItem.ImmutableFieldsEqual(rItem) {
+				change := &Change{
+					Kind:          lItem.Kind,
+					Name:          lItem.Name,
+					CurrentState:  currentItemConfig,
+					DesiredState:  desiredItemConfig,
+					DesiredConfig: lItem.DesiredConfig(rItem),
+				}
 				changeset.Update = append(changeset.Update, change)
 			} else {
 				deleteChange := &Change{
-					Kind:         lItem.Kind,
-					Name:         lItem.Name,
-					CurrentState: currentItemConfig,
-					DesiredState: "",
+					Kind:          lItem.Kind,
+					Name:          lItem.Name,
+					CurrentState:  currentItemConfig,
+					DesiredState:  "",
+					DesiredConfig: "",
 				}
 				changeset.Delete = append(changeset.Delete, deleteChange)
 				createChange := &Change{
-					Kind:         lItem.Kind,
-					Name:         lItem.Name,
-					CurrentState: "",
-					DesiredState: desiredItemConfig,
+					Kind:          lItem.Kind,
+					Name:          lItem.Name,
+					CurrentState:  "",
+					DesiredState:  desiredItemConfig,
+					DesiredConfig: desiredItemConfig,
 				}
 				changeset.Create = append(changeset.Create, createChange)
 			}

--- a/openshift/item.go
+++ b/openshift/item.go
@@ -14,11 +14,12 @@ var (
 )
 
 type ResourceItem struct {
-	Kind    string
-	Name    string
-	Labels  map[string]interface{}
-	Pointer string
-	Config  interface{}
+	Kind           string
+	Name           string
+	Labels         map[string]interface{}
+	Pointer        string
+	Config         interface{}
+	OriginalValues map[string]interface{}
 }
 
 func (i *ResourceItem) FullName() string {
@@ -27,6 +28,20 @@ func (i *ResourceItem) FullName() string {
 
 func (i *ResourceItem) YamlConfig() string {
 	y, _ := yaml.Marshal(i.Config)
+	return string(y)
+}
+
+func (i *ResourceItem) DesiredConfig(currentItem *ResourceItem) string {
+	c := i.Config
+	for k, v := range currentItem.OriginalValues {
+		pointer, _ := gojsonpointer.NewJsonPointer(k)
+		desiredVal, _, _ := pointer.Get(c)
+		currentVal, _, _ := pointer.Get(currentItem.Config)
+		if desiredVal == currentVal {
+			pointer.Set(c, v)
+		}
+	}
+	y, _ := yaml.Marshal(c)
 	return string(y)
 }
 

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -179,7 +179,7 @@ func ocDelete(change *Change, compareOptions *cli.CompareOptions) error {
 func ocApply(change *Change, action string, compareOptions *cli.CompareOptions) error {
 	kind := change.Kind
 	name := change.Name
-	config := change.DesiredState
+	config := change.DesiredConfig
 	fmt.Println(action, kind, name)
 	ioutil.WriteFile(".PROCESSED_TEMPLATE", []byte(config), 0644)
 


### PR DESCRIPTION
Before applying config, we need to reset the configuration value of
all modified keys to the actual value if they have not been changed.

Fixes #38.