### PR TITLE
Treat creationTimestamp as platform managed field

### DIFF
--- a/e2e/full_test.go
+++ b/e2e/full_test.go
@@ -26,7 +26,6 @@ func TestFullScope(t *testing.T) {
 		`apiVersion: v1
 kind: Template
 metadata:
-  creationTimestamp: null
   name: configmap
 objects:
 - apiVersion: v1
@@ -34,7 +33,6 @@ objects:
     bar: baz
   kind: ConfigMap
   metadata:
-    creationTimestamp: null
     name: foo
 `)
 	ioutil.WriteFile("cm-template.yml", cmBytes, 0644)

--- a/e2e/partial_test.go
+++ b/e2e/partial_test.go
@@ -24,13 +24,11 @@ func TestPartialScope(t *testing.T) {
 		`apiVersion: v1
 kind: Template
 metadata:
-  creationTimestamp: null
   name: configmap
 objects:
 - apiVersion: v1
   kind: ConfigMap
   metadata:
-    creationTimestamp: null
     name: foo
     labels:
       app: foo
@@ -39,7 +37,6 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    creationTimestamp: null
     labels:
       app: foo
     name: foo
@@ -61,13 +58,11 @@ objects:
 		`apiVersion: v1
 kind: Template
 metadata:
-  creationTimestamp: null
   name: configmap
 objects:
 - apiVersion: v1
   kind: ConfigMap
   metadata:
-    creationTimestamp: null
     name: bar
     labels:
       app: bar
@@ -76,7 +71,6 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    creationTimestamp: null
     labels:
       app: bar
     name: bar

--- a/openshift/change_test.go
+++ b/openshift/change_test.go
@@ -101,9 +101,9 @@ func TestDiff(t *testing.T) {
 +  annotations:
 +    foo: bar
 +    managed-annotations.tailor.opendevstack.org: foo
-   creationTimestamp: null
    labels:
      app: bar
+   name: bar
 `,
 			[]*JsonPatch{
 				&JsonPatch{
@@ -133,9 +133,9 @@ func TestDiff(t *testing.T) {
 -    foo: bar
 -    managed-annotations.tailor.opendevstack.org: foo
 +  annotations: {}
-   creationTimestamp: null
    labels:
      app: bar
+   name: bar
 `,
 			[]*JsonPatch{
 				&JsonPatch{
@@ -162,8 +162,8 @@ func TestDiff(t *testing.T) {
 -    foo: bar
 +    foo: baz
      managed-annotations.tailor.opendevstack.org: foo
-   creationTimestamp: null
    labels:
+     app: bar
 `,
 			[]*JsonPatch{
 				&JsonPatch{
@@ -189,9 +189,9 @@ func TestDiff(t *testing.T) {
      foo: bar
 -    managed-annotations.tailor.opendevstack.org: foo
 +    managed-annotations.tailor.opendevstack.org: baz,foo
-   creationTimestamp: null
    labels:
      app: bar
+   name: bar
 `,
 			[]*JsonPatch{
 				&JsonPatch{
@@ -219,9 +219,9 @@ func TestDiff(t *testing.T) {
      foo: bar
 -    managed-annotations.tailor.opendevstack.org: foo
 +    managed-annotations.tailor.opendevstack.org: baz,foo
-   creationTimestamp: null
    labels:
      app: bar
+   name: bar
 `,
 			[]*JsonPatch{
 				&JsonPatch{
@@ -270,7 +270,6 @@ func getConfigMapForDiff(annotations, data []byte) []byte {
 		`apiVersion: v1
 kind: ConfigMap
 metadata:
-  creationTimestamp: null
   labels:
     app: bar
   annotations: ANNOTATIONS

--- a/openshift/changeset_test.go
+++ b/openshift/changeset_test.go
@@ -12,7 +12,6 @@ items:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
-    creationTimestamp: null
     labels:
       template: foo-template
     name: foo
@@ -38,7 +37,6 @@ items:
       pv.kubernetes.io/bind-completed: "yes"
       pv.kubernetes.io/bound-by-controller: "yes"
       volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/aws-ebs
-    creationTimestamp: null
     labels:
       template: foo-template
     name: foo
@@ -77,7 +75,6 @@ items:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
-    creationTimestamp: null
     name: foo
     labels:
       app: foo
@@ -99,7 +96,6 @@ items:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
-    creationTimestamp: null
     name: foo
     annotations:
       kubectl.kubernetes.io/last-applied-configuration: >
@@ -137,7 +133,6 @@ items:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
-    creationTimestamp: null
     name: foo
   spec:
     accessModes:
@@ -156,7 +151,6 @@ items:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
-    creationTimestamp: null
     name: bar
   spec:
     accessModes:
@@ -193,7 +187,6 @@ items:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
-    creationTimestamp: null
     name: foo
   spec:
     accessModes:

--- a/openshift/item.go
+++ b/openshift/item.go
@@ -15,9 +15,11 @@ var (
 	//tailorIgnoredAnnotation = "ignored-fields.tailor.opendevstack.org"
 	platformManagedFields = []string{
 		"/metadata/generation",
+		"/metadata/creationTimestamp",
 		"/spec/tags",
 		"/status",
 		"/spec/volumeName",
+		"/spec/template/metadata/creationTimestamp",
 	}
 	emptyMapFields = []string{
 		"/metadata/annotations",

--- a/openshift/item_test.go
+++ b/openshift/item_test.go
@@ -204,7 +204,6 @@ func getConfigMap(annotations []byte) []byte {
 		`apiVersion: v1
 kind: ConfigMap
 metadata:
-  creationTimestamp: null
   labels:
     app: bar
   annotations: ANNOTATIONS
@@ -220,7 +219,6 @@ func getBuildConfig() []byte {
 kind: BuildConfig
 metadata:
   annotations: {}
-  creationTimestamp: null
   labels:
     app: foo
   name: foo
@@ -257,7 +255,6 @@ kind: BuildConfig
 metadata:
   annotations:
     foo: bar
-  creationTimestamp: null
   name: foo
 spec:
   failedBuildsHistoryLimit: 8
@@ -288,7 +285,6 @@ func getRoute(host []byte) []byte {
 kind: Route
 metadata:
   annotations: {}
-  creationTimestamp: null
   name: foo
 spec:
   host: HOST
@@ -309,7 +305,6 @@ func getTemplateDeploymentConfig(tag []byte) []byte {
 		`apiVersion: v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   name: foo
 spec:
   replicas: 1
@@ -320,7 +315,6 @@ spec:
   template:
     metadata:
       annotations: {}
-      creationTimestamp: null
       labels:
         name: foo
     spec:
@@ -345,7 +339,6 @@ func getPlatformDeploymentConfig() []byte {
 		`apiVersion: v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   name: foo
   annotations:
     original-values.tailor.io/spec.template.spec.containers.0.image: 'bar/foo:latest'
@@ -358,7 +351,6 @@ spec:
   template:
     metadata:
       annotations: {}
-      creationTimestamp: null
       labels:
         name: foo
     spec:

--- a/openshift/list_test.go
+++ b/openshift/list_test.go
@@ -11,7 +11,6 @@ items:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
-    creationTimestamp: null
     name: foo
   spec:
     accessModes:
@@ -24,7 +23,6 @@ items:
 - apiVersion: v1
   kind: ConfigMap
   metadata:
-    creationTimestamp: null
     name: bar
   data:
     bar: baz
@@ -59,7 +57,6 @@ items:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
-    creationTimestamp: null
     name: foo
   spec:
     accessModes:
@@ -72,7 +69,6 @@ items:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
-    creationTimestamp: null
     name: bar
   spec:
     accessModes:
@@ -113,7 +109,6 @@ items:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
-    creationTimestamp: null
     labels:
       app: foo
     name: foo
@@ -128,7 +123,6 @@ items:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
-    creationTimestamp: null
     labels:
       app: bar
     name: bar
@@ -143,7 +137,6 @@ items:
 - apiVersion: v1
   kind: ConfigMap
   metadata:
-    creationTimestamp: null
     labels:
       app: foo
     name: foo
@@ -152,7 +145,6 @@ items:
 - apiVersion: v1
   kind: ConfigMap
   metadata:
-    creationTimestamp: null
     labels:
       app: bar
     name: bar
@@ -163,7 +155,6 @@ items:
     auth-token: abcdef
   kind: Secret
   metadata:
-    creationTimestamp: null
     name: bar
     labels:
       app: bar


### PR DESCRIPTION
There is no point in specyfing this field in a template. OCP should
control it.

Closes #48.