### PR TITLE
Implement flag to ignore paths

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -209,7 +209,7 @@ func (o *CompareOptions) UpdateWithFile(fileFlags map[string]string) {
 	if fileFlags["upsert-only"] == "true" {
 		o.UpsertOnly = true
 	}
-	if val, ok := fileFlags["ignore-paths"]; ok {
+	if val, ok := fileFlags["ignore-path"]; ok {
 		o.IgnorePaths = strings.Split(val, ",")
 	}
 	if val, ok := fileFlags["resource"]; ok {

--- a/cli/options.go
+++ b/cli/options.go
@@ -30,6 +30,7 @@ type CompareOptions struct {
 	Params                  []string
 	ParamFiles              []string
 	Diff                    string
+	IgnorePaths             []string
 	IgnoreUnknownParameters bool
 	UpsertOnly              bool
 	Resource                string
@@ -208,12 +209,15 @@ func (o *CompareOptions) UpdateWithFile(fileFlags map[string]string) {
 	if fileFlags["upsert-only"] == "true" {
 		o.UpsertOnly = true
 	}
+	if val, ok := fileFlags["ignore-paths"]; ok {
+		o.IgnorePaths = strings.Split(val, ",")
+	}
 	if val, ok := fileFlags["resource"]; ok {
 		o.Resource = val
 	}
 }
 
-func (o *CompareOptions) UpdateWithFlags(labelsFlag string, paramFlag []string, paramFileFlag []string, diffFlag string, ignoreUnknownParametersFlag bool, upsertOnlyFlag bool, resourceArg string) {
+func (o *CompareOptions) UpdateWithFlags(labelsFlag string, paramFlag []string, paramFileFlag []string, diffFlag string, ignorePathFlag []string, ignoreUnknownParametersFlag bool, upsertOnlyFlag bool, resourceArg string) {
 	if len(labelsFlag) > 0 {
 		o.Labels = labelsFlag
 	}
@@ -254,6 +258,9 @@ func (o *CompareOptions) UpdateWithFlags(labelsFlag string, paramFlag []string, 
 	}
 	if upsertOnlyFlag {
 		o.UpsertOnly = true
+	}
+	if len(ignorePathFlag) > 0 {
+		o.IgnorePaths = ignorePathFlag
 	}
 	if len(resourceArg) > 0 {
 		o.Resource = resourceArg

--- a/main.go
+++ b/main.go
@@ -95,8 +95,8 @@ var (
 	).Default("text").String()
 	statusIgnorePathFlag = statusCommand.Flag(
 		"ignore-path",
-		"Path(s) per kind to ignore (e.g. because they are externally modified) in RFC 6901 format.",
-	).Default("bc:/spec/output/to/name").Strings()
+		"Path(s) per kind/name to ignore (e.g. because they are externally modified) in RFC 6901 format.",
+	).PlaceHolder("bc:foobar:/spec/output/to/name").Strings()
 	statusIgnoreUnknownParametersFlag = statusCommand.Flag(
 		"ignore-unknown-parameters",
 		"If true, will not stop processing if a provided parameter does not exist in the template.",
@@ -132,7 +132,7 @@ var (
 	updateIgnorePathFlag = updateCommand.Flag(
 		"ignore-path",
 		"Path(s) per kind to ignore (e.g. because they are externally modified) in RFC 6901 format.",
-	).Default("bc:/spec/output/to/name").Strings()
+	).PlaceHolder("bc:foobar:/spec/output/to/name").Strings()
 	updateIgnoreUnknownParametersFlag = updateCommand.Flag(
 		"ignore-unknown-parameters",
 		"If true, will not stop processing if a provided parameter does not exist in the template.",

--- a/openshift/change_test.go
+++ b/openshift/change_test.go
@@ -244,7 +244,7 @@ func TestDiff(t *testing.T) {
 			getConfigMapForDiff(tt.desiredAnnotations, tt.desiredData),
 			"template",
 		)
-		changes, err := desiredItem.ChangesFrom(currentItem)
+		changes, err := desiredItem.ChangesFrom(currentItem, []string{})
 		if err != nil {
 			t.Errorf(err.Error())
 		}

--- a/openshift/changeset.go
+++ b/openshift/changeset.go
@@ -1,6 +1,7 @@
 package openshift
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -79,8 +80,19 @@ func NewChangeset(platformBasedList, templateBasedList *ResourceList, upsertOnly
 			externallyModifiedPaths := []string{}
 			for _, path := range ignoredPaths {
 				pathParts := strings.Split(path, ":")
-				if templateItem.Kind == KindMapping[strings.ToLower(pathParts[0])] {
-					externallyModifiedPaths = append(externallyModifiedPaths, pathParts[1])
+				if len(pathParts) > 3 {
+					return changeset, fmt.Errorf(
+						"%s is not a valid ignore-path argument",
+						path,
+					)
+				}
+				if len(pathParts) == 1 ||
+					(len(pathParts) == 2 &&
+						templateItem.Kind == KindMapping[strings.ToLower(pathParts[0])]) ||
+					(len(pathParts) == 3 &&
+						templateItem.Kind == KindMapping[strings.ToLower(pathParts[0])] &&
+						templateItem.Name == strings.ToLower(pathParts[1])) {
+					externallyModifiedPaths = append(externallyModifiedPaths, pathParts[len(pathParts)-1])
 				}
 			}
 

--- a/openshift/changeset_test.go
+++ b/openshift/changeset_test.go
@@ -108,7 +108,7 @@ metadata: {}
 	platformBasedList.CollectItemsFromPlatformList(platformInput)
 	templateBasedList := &ResourceList{Filter: filter}
 	templateBasedList.CollectItemsFromTemplateList(templateInput)
-	changeset, err := NewChangeset(platformBasedList, templateBasedList, false)
+	changeset, err := NewChangeset(platformBasedList, templateBasedList, false, []string{})
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -169,7 +169,7 @@ metadata: {}
 	platformBasedList.CollectItemsFromPlatformList(platformInput)
 	templateBasedList := &ResourceList{Filter: filter}
 	templateBasedList.CollectItemsFromTemplateList(templateInput)
-	changeset, err := NewChangeset(platformBasedList, templateBasedList, false)
+	changeset, err := NewChangeset(platformBasedList, templateBasedList, false, []string{})
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -222,7 +222,7 @@ metadata: {}`)
 	platformBasedList.CollectItemsFromPlatformList(platformInput)
 	templateBasedList := &ResourceList{Filter: filter}
 	templateBasedList.CollectItemsFromTemplateList(templateInput)
-	changeset, err := NewChangeset(platformBasedList, templateBasedList, false)
+	changeset, err := NewChangeset(platformBasedList, templateBasedList, false, []string{})
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -261,7 +261,7 @@ metadata: {}
 	platformBasedList.CollectItemsFromPlatformList(platformInput)
 	templateBasedList := &ResourceList{Filter: filter}
 	templateBasedList.CollectItemsFromTemplateList(templateInput)
-	changeset, err := NewChangeset(platformBasedList, templateBasedList, false)
+	changeset, err := NewChangeset(platformBasedList, templateBasedList, false, []string{})
 	if err != nil {
 		t.Errorf(err.Error())
 	}

--- a/openshift/item_test.go
+++ b/openshift/item_test.go
@@ -24,13 +24,13 @@ func TestNewResourceItem(t *testing.T) {
 func TestChangesFromEqual(t *testing.T) {
 	currentItem := getItem(t, getBuildConfig(), "platform")
 	desiredItem := getItem(t, getBuildConfig(), "template")
-	desiredItem.ChangesFrom(currentItem)
+	desiredItem.ChangesFrom(currentItem, []string{})
 }
 
 func TestChangesFromDifferent(t *testing.T) {
 	currentItem := getItem(t, getBuildConfig(), "platform")
 	desiredItem := getItem(t, getChangedBuildConfig(), "template")
-	changes, err := desiredItem.ChangesFrom(currentItem)
+	changes, err := desiredItem.ChangesFrom(currentItem, []string{})
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -44,7 +44,7 @@ func TestChangesFromImmutableFields(t *testing.T) {
 	platformItem := getItem(t, getRoute([]byte("old.com")), "platform")
 
 	unchangedTemplateItem := getItem(t, getRoute([]byte("old.com")), "template")
-	changes, err := unchangedTemplateItem.ChangesFrom(platformItem)
+	changes, err := unchangedTemplateItem.ChangesFrom(platformItem, []string{})
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -53,7 +53,7 @@ func TestChangesFromImmutableFields(t *testing.T) {
 	}
 
 	changedTemplateItem := getItem(t, getRoute([]byte("new.com")), "template")
-	changes, err = changedTemplateItem.ChangesFrom(platformItem)
+	changes, err = changedTemplateItem.ChangesFrom(platformItem, []string{})
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -65,7 +65,7 @@ func TestChangesFromImmutableFields(t *testing.T) {
 func TestChangesFromPlatformModifiedFields(t *testing.T) {
 	platformItem := getItem(t, getPlatformDeploymentConfig(), "platform")
 	templateItem := getItem(t, getTemplateDeploymentConfig([]byte("latest")), "template")
-	changes, err := templateItem.ChangesFrom(platformItem)
+	changes, err := templateItem.ChangesFrom(platformItem, []string{})
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -74,7 +74,7 @@ func TestChangesFromPlatformModifiedFields(t *testing.T) {
 	}
 
 	changedTemplateItem := getItem(t, getTemplateDeploymentConfig([]byte("test")), "template")
-	changes, err = changedTemplateItem.ChangesFrom(platformItem)
+	changes, err = changedTemplateItem.ChangesFrom(platformItem, []string{})
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -108,7 +108,7 @@ func TestChangesFromAnnotationFields(t *testing.T) {
 	t.Log("> Adding an annotation in the template")
 	platformItem := getItem(t, getConfigMap([]byte("{}")), "platform")
 	templateItem := getItem(t, getConfigMap([]byte("{foo: bar}")), "template")
-	changes, err := templateItem.ChangesFrom(platformItem)
+	changes, err := templateItem.ChangesFrom(platformItem, []string{})
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -137,7 +137,7 @@ func TestChangesFromAnnotationFields(t *testing.T) {
 	t.Log("> Having a platform-managed annotation")
 	platformItem = getItem(t, getConfigMap([]byte("{foo: bar}")), "platform")
 	templateItem = getItem(t, getConfigMap([]byte("{}")), "template")
-	changes, err = templateItem.ChangesFrom(platformItem)
+	changes, err = templateItem.ChangesFrom(platformItem, []string{})
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -151,7 +151,7 @@ func TestChangesFromAnnotationFields(t *testing.T) {
 	t.Log("> Adding a platform-managed annotation from the template")
 	platformItem = getItem(t, getConfigMap([]byte("{foo: bar}")), "platform")
 	templateItem = getItem(t, getConfigMap([]byte("{foo: bar}")), "template")
-	changes, err = templateItem.ChangesFrom(platformItem)
+	changes, err = templateItem.ChangesFrom(platformItem, []string{})
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -171,7 +171,7 @@ func TestChangesFromAnnotationFields(t *testing.T) {
 	t.Log("> Changing a platform-managed annotation from the template")
 	platformItem = getItem(t, getConfigMap([]byte("{foo: bar}")), "platform")
 	templateItem = getItem(t, getConfigMap([]byte("{foo: baz}")), "template")
-	changes, err = templateItem.ChangesFrom(platformItem)
+	changes, err = templateItem.ChangesFrom(platformItem, []string{})
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -196,7 +196,7 @@ func TestChangesFromAnnotationFields(t *testing.T) {
 
 	t.Log("> - Modifying it")
 	templateItem = getItem(t, getConfigMap([]byte("{foo: baz}")), "template")
-	changes, err = templateItem.ChangesFrom(platformItem)
+	changes, err = templateItem.ChangesFrom(platformItem, []string{})
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -215,7 +215,7 @@ func TestChangesFromAnnotationFields(t *testing.T) {
 
 	t.Log("> - Removing it")
 	templateItem = getItem(t, getConfigMap([]byte("{}")), "template")
-	changes, err = templateItem.ChangesFrom(platformItem)
+	changes, err = templateItem.ChangesFrom(platformItem, []string{})
 	if err != nil {
 		t.Errorf(err.Error())
 	}

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -13,6 +13,28 @@ import (
 	"github.com/xeipuuv/gojsonpointer"
 )
 
+var (
+	KindMapping = map[string]string{
+		"svc":                   "Service",
+		"service":               "Service",
+		"route":                 "Route",
+		"dc":                    "DeploymentConfig",
+		"deploymentconfig":      "DeploymentConfig",
+		"bc":                    "BuildConfig",
+		"buildconfig":           "BuildConfig",
+		"is":                    "ImageStream",
+		"imagestream":           "ImageStream",
+		"pvc":                   "PersistentVolumeClaim",
+		"persistentvolumeclaim": "PersistentVolumeClaim",
+		"template":              "Template",
+		"cm":                    "ConfigMap",
+		"configmap":             "ConfigMap",
+		"secret":                "Secret",
+		"rolebinding":           "RoleBinding",
+		"serviceaccount":        "ServiceAccount",
+	}
+)
+
 func ExportAsTemplate(filter *ResourceFilter, name string, exportOptions *cli.ExportOptions) (string, error) {
 	ret := ""
 	args := []string{"export", "--as-template=" + name, "--output=yaml"}


### PR DESCRIPTION
Closes #45.

We still need better error handling, and proper tests.

Further, we need to answer the question if we need more than the proposed changes: potentially we need to ignore paths per-resource, not just per-kind ...