### PR TITLE
Warn before all resources are deleted

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -33,6 +33,7 @@ type CompareOptions struct {
 	IgnorePaths             []string
 	IgnoreUnknownParameters bool
 	UpsertOnly              bool
+	Force                   bool
 	Resource                string
 }
 
@@ -209,6 +210,9 @@ func (o *CompareOptions) UpdateWithFile(fileFlags map[string]string) {
 	if fileFlags["upsert-only"] == "true" {
 		o.UpsertOnly = true
 	}
+	if fileFlags["force"] == "true" {
+		o.Force = true
+	}
 	if val, ok := fileFlags["ignore-path"]; ok {
 		o.IgnorePaths = strings.Split(val, ",")
 	}
@@ -217,7 +221,7 @@ func (o *CompareOptions) UpdateWithFile(fileFlags map[string]string) {
 	}
 }
 
-func (o *CompareOptions) UpdateWithFlags(labelsFlag string, paramFlag []string, paramFileFlag []string, diffFlag string, ignorePathFlag []string, ignoreUnknownParametersFlag bool, upsertOnlyFlag bool, resourceArg string) {
+func (o *CompareOptions) UpdateWithFlags(labelsFlag string, paramFlag []string, paramFileFlag []string, diffFlag string, ignorePathFlag []string, ignoreUnknownParametersFlag bool, upsertOnlyFlag bool, forceFlag bool, resourceArg string) {
 	if len(labelsFlag) > 0 {
 		o.Labels = labelsFlag
 	}
@@ -258,6 +262,9 @@ func (o *CompareOptions) UpdateWithFlags(labelsFlag string, paramFlag []string, 
 	}
 	if upsertOnlyFlag {
 		o.UpsertOnly = true
+	}
+	if forceFlag {
+		o.Force = true
 	}
 	if len(ignorePathFlag) > 0 {
 		o.IgnorePaths = ignorePathFlag


### PR DESCRIPTION
Since we assume that the command is an error by the user, Tailor refuses
to delete all resources without --force.

Closes #64.

@clemensutschig Does that look good to you?