### PR TITLE
Ignore selector when exact resource is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Changed
+
+* Ignore selector (e.g. set in a `Tailorfile`) when a specific resource is
+  given as Openshift does not accept both selector and resource (#72).
+
 ## 0.9.0 (2018-10-29)
 
 * [Feature] Rewrite diff engine. Tailor now uses `oc patch` under the hood to

--- a/cli/options.go
+++ b/cli/options.go
@@ -276,20 +276,24 @@ func (o *CompareOptions) UpdateWithFlags(labelsFlag string, paramFlag []string, 
 
 func (o *CompareOptions) Process() error {
 	if (len(o.ParamDirs) > 1 || o.ParamDirs[0] != ".") && len(o.ParamFiles) > 0 {
-		return errors.New("You cannot specify both --param-dir and --param-file.")
+		return errors.New("You cannot specify both --param-dir and --param-file")
 	}
 	for _, p := range o.ParamDirs {
 		if p != "." {
 			if _, err := os.Stat(p); os.IsNotExist(err) {
-				return fmt.Errorf("Param directory %s does not exist.", p)
+				return fmt.Errorf("Param directory %s does not exist", p)
 			}
 		}
 	}
 	if o.Diff != "text" && o.Diff != "json" {
-		return errors.New("--diff must be either text or json.")
+		return errors.New("--diff must be either text or json")
 	}
 	if !o.CheckLoggedIn() {
-		return errors.New("You need to login with 'oc login' first.")
+		return errors.New("You need to login with 'oc login' first")
+	}
+	if strings.Contains(o.Resource, "/") && len(o.Selector) > 0 {
+		DebugMsg("Ignoring selector", o.Selector, "as resource is given")
+		o.Selector = ""
 	}
 	return nil
 }
@@ -308,7 +312,11 @@ func (o *ExportOptions) UpdateWithFlags(resourceArg string) {
 
 func (o *ExportOptions) Process() error {
 	if !o.CheckLoggedIn() {
-		return errors.New("You need to login with 'oc login' first.")
+		return errors.New("You need to login with 'oc login' first")
+	}
+	if strings.Contains(o.Resource, "/") && len(o.Selector) > 0 {
+		DebugMsg("Ignoring selector", o.Selector, "as resource is given")
+		o.Selector = ""
 	}
 	return nil
 }


### PR DESCRIPTION
OpenShift refuses to accept both selector and resource, so we prioritise
the resource if both is given. That might happen frequently, e.g.
because a default selector is set in the `Tailorfile`, but an ad-hoc
command against just one resource is made.

Closes #69.