### PR TITLE
Remove unmanaged annotations in exported templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   given as Openshift does not accept both selector and resource (#72).
 * Surface errors during export as template (#70).
 
+### Fixed
+
+* Remove annotations from exported templates also in case they contain slashes
+  (#73).
+
 ## 0.9.0 (2018-10-29)
 
 * [Feature] Rewrite diff engine. Tailor now uses `oc patch` under the hood to

--- a/utils/string.go
+++ b/utils/string.go
@@ -31,3 +31,10 @@ func Remove(s []string, val string) []string {
 	}
 	return s
 }
+
+// JSONPointerPath builds a JSON pointer path according to spec, see
+// https://tools.ietf.org/html/draft-ietf-appsawg-json-pointer-07#section-3.
+func JSONPointerPath(s string) string {
+	pointer := strings.Replace(s, "~", "~0", -1)
+	return strings.Replace(pointer, "/", "~1", -1)
+}


### PR DESCRIPTION
This was only working for annotations without a slash, as that is a
special character in the JSON pointer spec.

Now it works for all annotations.

Fixes #71.