### PR TITLE
Pass TAILOR_NAMESPACE params automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+
+* Automatically pass `TAILOR_NAMESPACE` param to templates if they define it in
+  the `parameters` section. The value is set to the namespace that Tailor runs
+  against (#77).
+
 ### Changed
 
 * Remove metadata from template as it is unsused by Tailor (#74).


### PR DESCRIPTION
Templates often need an OCP namespace, and typically it should be the
one for which Tailor is invoked.

If a template contains a param named TAILOR_NAMESPACE, it is
automatically set to the namespace that Tailor runs against.

Addresses #47.