### PR TITLE
Replace deprecated oc export command

### DIFF
--- a/openshift/item.go
+++ b/openshift/item.go
@@ -23,6 +23,7 @@ var (
 		"/status",
 		"/spec/volumeName",
 		"/spec/template/metadata/creationTimestamp",
+		"/spec/clusterIP",
 		"/metadata/namespace",
 		"/metadata/resourceVersion",
 		"/metadata/selfLink",

--- a/openshift/item.go
+++ b/openshift/item.go
@@ -23,6 +23,10 @@ var (
 		"/status",
 		"/spec/volumeName",
 		"/spec/template/metadata/creationTimestamp",
+		"/metadata/namespace",
+		"/metadata/resourceVersion",
+		"/metadata/selfLink",
+		"/metadata/uid",
 	}
 	platformManagedRegexFields = []string{
 		"^/spec/triggers/[0-9]*/imageChangeParams/lastTriggeredImage",
@@ -239,10 +243,7 @@ func (i *ResourceItem) parseConfig(m map[string]interface{}) error {
 	}
 
 	// Remove platform-managed simple fields
-	for _, p := range platformManagedSimpleFields {
-		deletePointer, _ := gojsonpointer.NewJsonPointer(p)
-		_, _ = deletePointer.Delete(m)
-	}
+	i.removePlatformManagedFields(m)
 
 	i.Config = m
 
@@ -334,6 +335,13 @@ func (i *ResourceItem) RemoveUnmanagedAnnotations() {
 				fmt.Printf("%v", i.Config)
 			}
 		}
+	}
+}
+func (i *ResourceItem) removePlatformManagedFields(m map[string]interface{}) {
+	for _, p := range platformManagedSimpleFields {
+		deletePointer, _ := gojsonpointer.NewJsonPointer(p)
+		_, _ = deletePointer.Delete(m)
+
 	}
 }
 

--- a/openshift/item_test.go
+++ b/openshift/item_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestNewResourceItem(t *testing.T) {
 	item := getItem(t, getBuildConfig(), "template")
+	metadata := item.Config["metadata"].(map[string]interface{})
 	if item.Kind != "BuildConfig" {
 		t.Errorf("Kind is %s but should be BuildConfig", item.Kind)
 	}
@@ -18,6 +19,18 @@ func TestNewResourceItem(t *testing.T) {
 	}
 	if item.Labels["app"] != "foo" {
 		t.Errorf("Label app is %s but should be foo", item.Labels["app"])
+	}
+	if metadata["namespace"] != nil {
+		t.Errorf("Platform managed property namespace should not be present in template")
+	}
+	if metadata["resourceVersion"] != nil {
+		t.Errorf("Platform managed property resourceVersion should not be present in template")
+	}
+	if metadata["selfLink"] != nil {
+		t.Errorf("Platform managed property selfLink should not be present in template")
+	}
+	if metadata["uid"] != nil {
+		t.Errorf("Platform managed property uid should not be present in template")
 	}
 }
 
@@ -266,6 +279,10 @@ metadata:
   labels:
     app: foo
   name: foo
+  namespace: foo-cd
+  resourceVersion: "123456789"
+  selfLink: /foo/test/1234
+  uid: 123-test-000
 spec:
   failedBuildsHistoryLimit: 5
   nodeSelector: null

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -126,7 +126,7 @@ func ExportAsTemplate(filter *ResourceFilter, exportOptions *cli.ExportOptions) 
 
 func ExportResources(filter *ResourceFilter, compareOptions *cli.CompareOptions) ([]byte, error) {
 	target := filter.ConvertToKinds()
-	args := []string{"export", target, "--output=yaml"}
+	args := []string{"get", target, "--output=yaml"}
 	cmd := cli.ExecOcCmd(
 		args,
 		compareOptions.Namespace,


### PR DESCRIPTION
#82 

The approach is to use the new `oc get --export` feature to export the list and then massage it to remove the cluster specific information. 

-- Reference : 
https://github.com/kubernetes/kubernetes/issues/28551#issuecomment-453532504
