### PR TITLE
Mask secrets in textual output by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tailor_linux_amd64
 tailor_darwin_amd64
 tailor_windows_amd64.exe
 openshift.local.clusterup/
+.vscode

--- a/cli/options.go
+++ b/cli/options.go
@@ -35,6 +35,7 @@ type CompareOptions struct {
 	IgnorePaths             []string
 	IgnoreUnknownParameters bool
 	UpsertOnly              bool
+	RevealSecrets           bool
 	Resource                string
 }
 
@@ -251,6 +252,9 @@ func (o *CompareOptions) UpdateWithFile(fileFlags map[string]string) {
 	if fileFlags["upsert-only"] == "true" {
 		o.UpsertOnly = true
 	}
+	if fileFlags["reveal-secrets"] == "true" {
+		o.RevealSecrets = true
+	}
 	if val, ok := fileFlags["ignore-path"]; ok {
 		o.IgnorePaths = strings.Split(val, ",")
 	}
@@ -259,7 +263,7 @@ func (o *CompareOptions) UpdateWithFile(fileFlags map[string]string) {
 	}
 }
 
-func (o *CompareOptions) UpdateWithFlags(labelsFlag string, paramFlag []string, paramFileFlag []string, diffFlag string, ignorePathFlag []string, ignoreUnknownParametersFlag bool, upsertOnlyFlag bool, resourceArg string) {
+func (o *CompareOptions) UpdateWithFlags(labelsFlag string, paramFlag []string, paramFileFlag []string, diffFlag string, ignorePathFlag []string, ignoreUnknownParametersFlag bool, upsertOnlyFlag bool, revealSecretsFlag bool, resourceArg string) {
 	if len(labelsFlag) > 0 {
 		o.Labels = labelsFlag
 	}
@@ -300,6 +304,9 @@ func (o *CompareOptions) UpdateWithFlags(labelsFlag string, paramFlag []string, 
 	}
 	if upsertOnlyFlag {
 		o.UpsertOnly = true
+	}
+	if revealSecretsFlag {
+		o.RevealSecrets = true
 	}
 	if len(ignorePathFlag) > 0 {
 		o.IgnorePaths = ignorePathFlag

--- a/commands/status.go
+++ b/commands/status.go
@@ -119,6 +119,7 @@ func calculateChangeset(compareOptions *cli.CompareOptions) (bool, *openshift.Ch
 		platformBasedList,
 		templateBasedList,
 		compareOptions.UpsertOnly,
+		compareOptions.RevealSecrets,
 		compareOptions.Diff,
 		compareOptions.IgnorePaths,
 	)
@@ -129,7 +130,7 @@ func calculateChangeset(compareOptions *cli.CompareOptions) (bool, *openshift.Ch
 	return updateRequired, changeset, nil
 }
 
-func compare(remoteResourceList *openshift.ResourceList, localResourceList *openshift.ResourceList, upsertOnly bool, diff string, ignorePaths []string) (*openshift.Changeset, error) {
+func compare(remoteResourceList *openshift.ResourceList, localResourceList *openshift.ResourceList, upsertOnly bool, revealSecrets bool, diff string, ignorePaths []string) (*openshift.Changeset, error) {
 	changeset, err := openshift.NewChangeset(remoteResourceList, localResourceList, upsertOnly, ignorePaths)
 	if err != nil {
 		return changeset, err
@@ -141,18 +142,18 @@ func compare(remoteResourceList *openshift.ResourceList, localResourceList *open
 
 	for _, change := range changeset.Delete {
 		cli.PrintRedf("- %s to delete\n", change.ItemName())
-		fmt.Printf(change.Diff())
+		fmt.Printf(change.Diff(revealSecrets))
 	}
 
 	for _, change := range changeset.Create {
 		cli.PrintGreenf("+ %s to create\n", change.ItemName())
-		fmt.Printf(change.Diff())
+		fmt.Printf(change.Diff(revealSecrets))
 	}
 
 	for _, change := range changeset.Update {
 		cli.PrintYellowf("~ %s to update\n", change.ItemName())
 		if diff == "text" {
-			fmt.Printf(change.Diff())
+			fmt.Printf(change.Diff(revealSecrets))
 		} else {
 			fmt.Println(change.JsonPatches(true))
 		}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0
+	github.com/stretchr/testify v1.3.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f
 	golang.org/x/crypto v0.0.0-20180820150726-614d502a4dac
 	gopkg.in/yaml.v2 v2.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5Vpd
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -14,6 +16,9 @@ github.com/mattn/go-isatty v0.0.3 h1:ns/ykhmWi7G9O+8a448SecJU3nSMBXJfqQkl0upE1jI
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 golang.org/x/crypto v0.0.0-20180820150726-614d502a4dac h1:7d7lG9fHOLdL6jZPtnV4LpI41SbohIJ1Atq7U991dMg=

--- a/main.go
+++ b/main.go
@@ -107,6 +107,10 @@ var (
 		"upsert-only",
 		"Don't delete resource, only create / update.",
 	).Short('u').Bool()
+	statusRevealSecretsFlag = statusCommand.Flag(
+		"reveal-secrets",
+		"Reveal secrets instead of masking them.",
+	).Bool()
 	statusResourceArg = statusCommand.Arg(
 		"resource", "Remote resource (defaults to all)",
 	).String()
@@ -143,6 +147,10 @@ var (
 		"upsert-only",
 		"Don't delete resource, only create / update.",
 	).Short('u').Bool()
+	updateRevealSecretsFlag = updateCommand.Flag(
+		"reveal-secrets",
+		"Reveal secrets instead of masking them.",
+	).Bool()
 	updateResourceArg = updateCommand.Arg(
 		"resource", "Remote resource (defaults to all)",
 	).String()
@@ -274,6 +282,7 @@ func main() {
 			*statusIgnorePathFlag,
 			*statusIgnoreUnknownParametersFlag,
 			*statusUpsertOnlyFlag,
+			*statusRevealSecretsFlag,
 			*statusResourceArg,
 		)
 		err := compareOptions.Process()
@@ -302,6 +311,7 @@ func main() {
 			*updateIgnorePathFlag,
 			*updateIgnoreUnknownParametersFlag,
 			*updateUpsertOnlyFlag,
+			*updateRevealSecretsFlag,
 			*updateResourceArg,
 		)
 		err := compareOptions.Process()

--- a/openshift/change.go
+++ b/openshift/change.go
@@ -24,12 +24,13 @@ var (
 )
 
 type Change struct {
-	Action       string
-	Kind         string
-	Name         string
-	Patches      []*jsonPatch
-	CurrentState string
-	DesiredState string
+	Action             string
+	Kind               string
+	Name               string
+	Patches            []*jsonPatch
+	CurrentState       string
+	DesiredState       string
+	MaskedDesiredState string
 }
 
 type jsonPatch struct {
@@ -52,10 +53,16 @@ func (c *Change) JsonPatches(pretty bool) string {
 	return string(b)
 }
 
-func (c *Change) Diff() string {
+func (c *Change) Diff(revealSecrets bool) string {
+	var desired string
+	if revealSecrets {
+		desired = c.DesiredState
+	} else {
+		desired = c.MaskedDesiredState
+	}
 	diff := difflib.UnifiedDiff{
 		A:        difflib.SplitLines(c.CurrentState),
-		B:        difflib.SplitLines(c.DesiredState),
+		B:        difflib.SplitLines(desired),
 		FromFile: "Current State (OpenShift cluster)",
 		ToFile:   "Desired State (Processed template)",
 		Context:  3,

--- a/openshift/change_test.go
+++ b/openshift/change_test.go
@@ -249,7 +249,7 @@ func TestDiff(t *testing.T) {
 			t.Errorf(err.Error())
 		}
 		change := changes[0]
-		actualDiff := change.Diff()
+		actualDiff := change.Diff(false)
 		if actualDiff != tt.expectedDiff {
 			t.Errorf(
 				"Diff()\n===== expected =====\n%s\n===== actual =====\n%s",
@@ -260,7 +260,7 @@ func TestDiff(t *testing.T) {
 		actualPatches := change.Patches
 		if !reflect.DeepEqual(actualPatches, tt.expectedPatches) {
 			t.Errorf(
-				"Diff()\n===== expected =====\n%s\n===== actual =====\n%s",
+				"Diff()\n===== expected =====\n%v\n===== actual =====\n%v",
 				tt.expectedPatches,
 				actualPatches,
 			)

--- a/openshift/changeset.go
+++ b/openshift/changeset.go
@@ -43,11 +43,12 @@ func NewChangeset(platformBasedList, templateBasedList *ResourceList, upsertOnly
 		for _, item := range platformBasedList.Items {
 			if _, err := templateBasedList.getItem(item.Kind, item.Name); err != nil {
 				change := &Change{
-					Action:       "Delete",
-					Kind:         item.Kind,
-					Name:         item.Name,
-					CurrentState: item.YamlConfig(),
-					DesiredState: "",
+					Action:             "Delete",
+					Kind:               item.Kind,
+					Name:               item.Name,
+					CurrentState:       item.YamlConfig(),
+					DesiredState:       "",
+					MaskedDesiredState: "",
 				}
 				changeset.Add(change)
 			}
@@ -58,11 +59,12 @@ func NewChangeset(platformBasedList, templateBasedList *ResourceList, upsertOnly
 	for _, item := range templateBasedList.Items {
 		if _, err := platformBasedList.getItem(item.Kind, item.Name); err != nil {
 			change := &Change{
-				Action:       "Create",
-				Kind:         item.Kind,
-				Name:         item.Name,
-				CurrentState: "",
-				DesiredState: item.YamlConfig(),
+				Action:             "Create",
+				Kind:               item.Kind,
+				Name:               item.Name,
+				CurrentState:       "",
+				DesiredState:       item.YamlConfig(),
+				MaskedDesiredState: item.MaskedYamlConfig(),
 			}
 			changeset.Add(change)
 		}

--- a/openshift/item_test.go
+++ b/openshift/item_test.go
@@ -234,37 +234,28 @@ func TestChangesFromAnnotationFields(t *testing.T) {
 }
 
 func TestMaskedYamlConfig(t *testing.T) {
-	examples := []struct {
-		name    string
+	tests := map[string]struct {
 		fixture string
 		golden  string
 	}{
-		{
-			"Config Map",
-			"../test/fixtures/config-map.yml",
-			"../test/golden/config-map.yml",
-		},
-		{
-			"Secret",
-			"../test/fixtures/secret.yml",
-			"../test/golden/secret.yml",
-		},
+		"Config Map": {fixture: "config-map.yml", golden: "config-map.yml"},
+		"Secret":     {fixture: "secret.yml", golden: "secret.yml"},
 	}
 
-	for _, example := range examples {
-		t.Run(example.name, func(t *testing.T) {
-			input, err := ioutil.ReadFile(example.fixture)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			input, err := ioutil.ReadFile("../test/fixtures/" + tc.fixture)
 			if err != nil {
 				t.Fatal(err)
 			}
 			item := getItem(t, input, "template")
-			expected, err := ioutil.ReadFile(example.golden)
+			want, err := ioutil.ReadFile("../test/golden/" + tc.golden)
 			if err != nil {
 				t.Fatal(err)
 			}
-			actual := item.MaskedYamlConfig()
-			if actual != string(expected) {
-				t.Fatalf("Got YAML config:\n%s, want:\n%s", actual, expected)
+			got := item.MaskedYamlConfig()
+			if got != string(want) {
+				t.Fatalf("want:\n%s, got:\n%s", want, got)
 			}
 		})
 	}

--- a/test/fixtures/config-map.yml
+++ b/test/fixtures/config-map.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: bar
+  annotations: {}
+  name: bar
+data:
+  bar: baz

--- a/test/fixtures/secret.yml
+++ b/test/fixtures/secret.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: bar
+  annotations: {}
+  name: bar
+data:
+  bar: c2VjcmV0

--- a/test/golden/config-map.yml
+++ b/test/golden/config-map.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  bar: baz
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    app: bar
+  name: bar

--- a/test/golden/secret.yml
+++ b/test/golden/secret.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  bar: '*****'
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    app: bar
+  name: bar


### PR DESCRIPTION
Users may choose to display secrets by passing `--reveal-secrets`.

Closes #109.

@hugowschneider Let me know if you want to review it - would appreciate it!