### PR TITLE
Refactor annotation handling (and more!)

### DIFF
--- a/cmd/tailor/main.go
+++ b/cmd/tailor/main.go
@@ -161,6 +161,10 @@ var (
 		"export",
 		"Export remote state as template",
 	)
+	exportWithAnnotationsFlag = exportCommand.Flag(
+		"with-annotations",
+		"Export annotations as well.",
+	).Bool()
 	exportResourceArg = exportCommand.Arg(
 		"resource", "Remote resource (defaults to all)",
 	).String()
@@ -381,6 +385,7 @@ func main() {
 				*excludeFlag,
 				*templateDirFlag,
 				*paramDirFlag,
+				*exportWithAnnotationsFlag,
 				*exportResourceArg,
 			)
 			if err != nil {

--- a/internal/test/fixtures/empty-values/bc-platform.yml
+++ b/internal/test/fixtures/empty-values/bc-platform.yml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  annotations: {}
+  labels:
+    app: foo
+  name: foo
+spec:
+  failedBuildsHistoryLimit: 5
+  nodeSelector: null
+  output:
+    to:
+      kind: ImageStreamTag
+      name: foo:latest
+  postCommit: {}
+  resources: {}
+  runPolicy: Serial
+  source:
+    binary: {}
+    type: Binary
+  strategy:
+    dockerStrategy: {}
+    type: Docker
+  successfulBuildsHistoryLimit: 5
+  triggers:
+  - generic:
+      secret: password
+    type: Generic
+  - imageChange: {}
+    type: ImageChange
+  - type: ConfigChange

--- a/internal/test/fixtures/empty-values/bc-template.yml
+++ b/internal/test/fixtures/empty-values/bc-template.yml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: foo
+  name: foo
+spec:
+  failedBuildsHistoryLimit: 5
+  output:
+    to:
+      kind: ImageStreamTag
+      name: foo:latest
+  runPolicy: Serial
+  source:
+    type: Binary
+  strategy:
+    type: Docker
+  successfulBuildsHistoryLimit: 5
+  triggers:
+  - generic:
+      secret: password
+    type: Generic
+  - type: ImageChange
+  - type: ConfigChange

--- a/internal/test/fixtures/export/is.yml
+++ b/internal/test/fixtures/export/is.yml
@@ -1,0 +1,34 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  creationTimestamp: null
+  name: tailor
+objects:
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      description: Keeps track of changes in the application image
+      openshift.io/image.dockerRepositoryCheck: 2018-08-07T12:32:24Z
+      tailor.opendevstack.org/managed-annotations: description
+    creationTimestamp: null
+    generation: 560
+    labels:
+      app: foo-bar
+    name: bar
+  spec:
+    dockerImageRepository: bar
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations: null
+      from:
+        kind: ImageStreamImage
+        name: bar@sha256:4e418dd975063c99f52d0d17076b54e38186a90deb34cd5c502ed045e9c385da
+      generation: 560
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: Source
+  status:
+    dockerImageRepository: ""

--- a/internal/test/fixtures/item-applied-config/dc-platform-annotation.yml
+++ b/internal/test/fixtures/item-applied-config/dc-platform-annotation.yml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: foo
+  annotations:
+    tailor.opendevstack.org/applied-config: '{"/spec/template/spec/containers/0/image": "bar/foo:latest"}'
+spec:
+  replicas: 1
+  selector:
+    name: foo
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        name: foo
+    spec:
+      containers:
+      - image: 192.168.0.1:5000/bar/foo@sha256:51ead8367892a487ca4a1ca7435fa418466901ca2842b777e15a12d0b470ab30
+        imagePullPolicy: IfNotPresent
+        name: foo
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: foo
+      serviceAccountName: foo
+      volumes: []
+  test: false
+  triggers: []

--- a/internal/test/fixtures/item-applied-config/dc-platform.yml
+++ b/internal/test/fixtures/item-applied-config/dc-platform.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: foo
+spec:
+  replicas: 1
+  selector:
+    name: foo
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        name: foo
+    spec:
+      containers:
+      - image: 192.168.0.1:5000/bar/foo@sha256:51ead8367892a487ca4a1ca7435fa418466901ca2842b777e15a12d0b470ab30
+        imagePullPolicy: IfNotPresent
+        name: foo
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: foo
+      serviceAccountName: foo
+      volumes: []
+  test: false
+  triggers: []

--- a/internal/test/fixtures/item-applied-config/dc-template-changed.yml
+++ b/internal/test/fixtures/item-applied-config/dc-template-changed.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: foo
+spec:
+  replicas: 1
+  selector:
+    name: foo
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        name: foo
+    spec:
+      containers:
+      - image: bar/foo:experiment
+        imagePullPolicy: IfNotPresent
+        name: foo
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: foo
+      serviceAccountName: foo
+      volumes: []
+  test: false
+  triggers: []

--- a/internal/test/fixtures/item-applied-config/dc-template.yml
+++ b/internal/test/fixtures/item-applied-config/dc-template.yml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: foo
+spec:
+  replicas: 1
+  selector:
+    name: foo
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        name: foo
+    spec:
+      containers:
+      - image: bar/foo:latest
+        imagePullPolicy: IfNotPresent
+        name: foo
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      serviceAccount: foo
+      serviceAccountName: foo
+  test: false
+  triggers: []

--- a/internal/test/fixtures/item-managed-annotations/is-platform-annotation.yml
+++ b/internal/test/fixtures/item-managed-annotations/is-platform-annotation.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ImageStream
+metadata:
+  name: foo
+  annotations:
+    bar: baz
+    tailor.opendevstack.org/managed-annotations: bar
+spec:
+  dockerImageRepository: foo
+  lookupPolicy:
+    local: false

--- a/internal/test/fixtures/item-managed-annotations/is-platform-unmanaged.yml
+++ b/internal/test/fixtures/item-managed-annotations/is-platform-unmanaged.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ImageStream
+metadata:
+  name: foo
+  annotations:
+    bar: baz
+spec:
+  dockerImageRepository: foo
+  lookupPolicy:
+    local: false

--- a/internal/test/fixtures/item-managed-annotations/is-platform.yml
+++ b/internal/test/fixtures/item-managed-annotations/is-platform.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ImageStream
+metadata:
+  name: foo
+spec:
+  dockerImageRepository: foo
+  lookupPolicy:
+    local: false

--- a/internal/test/fixtures/item-managed-annotations/is-template-annotation-changed.yml
+++ b/internal/test/fixtures/item-managed-annotations/is-template-annotation-changed.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ImageStream
+metadata:
+  name: foo
+  annotations:
+    bar: qux
+spec:
+  dockerImageRepository: foo
+  lookupPolicy:
+    local: false

--- a/internal/test/fixtures/item-managed-annotations/is-template-annotation.yml
+++ b/internal/test/fixtures/item-managed-annotations/is-template-annotation.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ImageStream
+metadata:
+  name: foo
+  annotations:
+    bar: baz
+spec:
+  dockerImageRepository: foo
+  lookupPolicy:
+    local: false

--- a/internal/test/fixtures/item-managed-annotations/is-template-different-annotation.yml
+++ b/internal/test/fixtures/item-managed-annotations/is-template-different-annotation.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ImageStream
+metadata:
+  name: foo
+  annotations:
+    baz: qux
+spec:
+  dockerImageRepository: foo
+  lookupPolicy:
+    local: false

--- a/internal/test/fixtures/item-managed-annotations/is-template.yml
+++ b/internal/test/fixtures/item-managed-annotations/is-template.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ImageStream
+metadata:
+  name: foo
+spec:
+  dockerImageRepository: foo
+  lookupPolicy:
+    local: false

--- a/internal/test/golden/export/is-annotation.yml
+++ b/internal/test/golden/export/is-annotation.yml
@@ -1,0 +1,16 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+objects:
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      description: Keeps track of changes in the application image
+      openshift.io/image.dockerRepositoryCheck: "2018-08-07T12:32:24Z"
+    labels:
+      app: foo-bar
+    name: bar
+  spec:
+    dockerImageRepository: bar
+    lookupPolicy:
+      local: false

--- a/internal/test/golden/export/is.yml
+++ b/internal/test/golden/export/is.yml
@@ -1,0 +1,13 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+objects:
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    labels:
+      app: foo-bar
+    name: bar
+  spec:
+    dockerImageRepository: bar
+    lookupPolicy:
+      local: false

--- a/internal/test/helper/file.go
+++ b/internal/test/helper/file.go
@@ -1,0 +1,46 @@
+package helper
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path"
+	"runtime"
+	"testing"
+)
+
+// ReadFixtureFileOrErr returns the contents of the fixture file or an error.
+func ReadFixtureFileOrErr(filename string) ([]byte, error) {
+	return readFileOrErr("../fixtures/" + filename)
+}
+
+// ReadGoldenFileOrErr returns the contents of the golden file or an error.
+func ReadGoldenFileOrErr(t *testing.T, filename string) ([]byte, error) {
+	return readFileOrErr("../golden/" + filename)
+}
+
+// ReadFixtureFile returns the contents of the fixture file or fails.
+func ReadFixtureFile(t *testing.T, filename string) []byte {
+	return readFile(t, "../fixtures/"+filename)
+}
+
+// ReadGoldenFile returns the contents of the golden file or fails.
+func ReadGoldenFile(t *testing.T, filename string) []byte {
+	return readFile(t, "../golden/"+filename)
+}
+
+func readFile(t *testing.T, name string) []byte {
+	b, err := readFileOrErr(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func readFileOrErr(name string) ([]byte, error) {
+	_, filename, _, ok := runtime.Caller(1)
+	if !ok {
+		return []byte{}, fmt.Errorf("Could not get filename when looking for %s", name)
+	}
+	filepath := path.Join(path.Dir(filename), name)
+	return ioutil.ReadFile(filepath)
+}

--- a/pkg/cli/oc_client.go
+++ b/pkg/cli/oc_client.go
@@ -1,0 +1,236 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+)
+
+// ClientProcessorExporter allows to process templates and export resources.
+type ClientProcessorExporter interface {
+	OcClientProcessor
+	OcClientExporter
+}
+
+// OcClientProcessor is a stop-gap solution only ... should have a better API.
+type OcClientProcessor interface {
+	Process(args []string) ([]byte, []byte, error)
+}
+
+// OcClientExporter allows to export resources.
+type OcClientExporter interface {
+	Export(target string, label string) ([]byte, error)
+}
+
+// OcClientPatcher allows to patch a resource.
+type OcClientPatcher interface {
+	Patch(target string, patches string) ([]byte, error)
+}
+
+// OcClientDeleter allows to delete a resource.
+type OcClientDeleter interface {
+	Delete(kind string, name string) ([]byte, error)
+}
+
+// OcClientCreator allows to create a resource.
+type OcClientCreator interface {
+	Create(config string, selector string) ([]byte, error)
+}
+
+// OpenshiftVersion represents the client/server version pair.
+type OpenshiftVersion struct {
+	Client string
+	Server string
+}
+
+// OcClient is a wrapper around the "oc" binary (client).
+type OcClient struct {
+	namespace string
+}
+
+// NewOcClient creates a new ocClient.
+func NewOcClient(namespace string) *OcClient {
+	return &OcClient{namespace: namespace}
+}
+
+// Matches is true when client and server version are equal.
+func (ov OpenshiftVersion) Matches() bool {
+	return ov.Client == ov.Server
+}
+
+// Version returns an OpenshiftVersion.
+func (c *OcClient) Version() (OpenshiftVersion, error) {
+	cmd := c.execPlainOcCmd([]string{"version"})
+	outBytes, errBytes, err := c.runCmd(cmd)
+	if err != nil {
+		return OpenshiftVersion{"?", "?"}, fmt.Errorf("Failed to query client and server version, got: %s", string(errBytes))
+	}
+	output := string(outBytes)
+
+	ocClientVersion := ""
+	ocServerVersion := ""
+	extractVersion := func(versionPart string) string {
+		ocVersionParts := strings.SplitN(versionPart, ".", 3)
+		return strings.Join(ocVersionParts[:len(ocVersionParts)-1], ".")
+	}
+
+	lines := strings.Split(strings.TrimSuffix(output, "\n"), "\n")
+	for _, line := range lines {
+		if len(line) > 0 {
+			parts := strings.SplitN(line, " ", 2)
+			if parts[0] == "oc" {
+				ocClientVersion = extractVersion(parts[1])
+			}
+			if parts[0] == "openshift" {
+				ocServerVersion = extractVersion(parts[1])
+			}
+		}
+	}
+
+	if len(ocClientVersion) == 0 || !strings.Contains(ocClientVersion, ".") {
+		ocClientVersion = "?"
+	}
+	if len(ocServerVersion) == 0 || !strings.Contains(ocServerVersion, ".") {
+		ocServerVersion = "?"
+	}
+
+	if ocClientVersion == "?" || ocServerVersion == "?" {
+		err = fmt.Errorf("Client and server version could not be detected properly, got: %s", output)
+	}
+
+	return OpenshiftVersion{Client: ocClientVersion, Server: ocServerVersion}, err
+}
+
+// CurrentProject returns the currently active project name (namespace).
+func (c *OcClient) CurrentProject() (string, error) {
+	cmd := c.execPlainOcCmd([]string{"project", "--short"})
+	n, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(n)), err
+}
+
+// CheckProjectExists returns true if the given project (namespace) exists.
+func (c *OcClient) CheckProjectExists(p string) (bool, error) {
+	cmd := c.execPlainOcCmd([]string{"project", p, "--short"})
+	_, err := cmd.CombinedOutput()
+	return err == nil, err
+}
+
+// CheckLoggedIn returns true if the given project (namespace) exists.
+func (c *OcClient) CheckLoggedIn() (bool, error) {
+	cmd := exec.Command(ocBinary, "whoami")
+	_, err := cmd.CombinedOutput()
+	return err == nil, err
+}
+
+// Process processes an OpenShift template.
+// The API is just a stop-gap solution and will be better in the future.
+func (c *OcClient) Process(args []string) ([]byte, []byte, error) {
+	processArgs := append([]string{"process"}, args...)
+	cmd := c.execPlainOcCmd(processArgs)
+	return c.runCmd(cmd)
+}
+
+// Export exports resources from OpenShift as a template.
+func (c *OcClient) Export(target string, label string) ([]byte, error) {
+	args := []string{"export", target, "--output=yaml", "--as-template=tailor"}
+	cmd := c.execOcCmd(
+		args,
+		c.namespace,
+		label,
+	)
+	outBytes, errBytes, err := c.runCmd(cmd)
+
+	if err != nil {
+		ret := string(errBytes)
+
+		if strings.Contains(ret, "no resources found") {
+			return []byte{}, nil
+		}
+
+		return []byte{}, fmt.Errorf(
+			"Failed to export %s resources.\n"+
+				"%s\n",
+			target,
+			ret,
+		)
+	}
+
+	return outBytes, nil
+}
+
+// Patch applies the given patch on the target.
+func (c *OcClient) Patch(target string, patches string) ([]byte, error) {
+	args := []string{"patch", target, "--type=json", "--patch", patches}
+	cmd := c.execOcCmd(
+		args,
+		c.namespace,
+		"", // empty as name and selector is not allowed
+	)
+	_, errBytes, err := c.runCmd(cmd)
+	return errBytes, err
+}
+
+// Create creates given resource configuration.
+func (c *OcClient) Create(config string, selector string) ([]byte, error) {
+	args := []string{"create", "-f", "-"}
+	cmd := c.execOcCmd(
+		args,
+		c.namespace,
+		selector,
+	)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	go func() {
+		defer stdin.Close()
+		_, _ = io.WriteString(stdin, config)
+	}()
+	_, errBytes, err := c.runCmd(cmd)
+	return errBytes, err
+}
+
+// Delete deletes given resource.
+func (c *OcClient) Delete(kind string, name string) ([]byte, error) {
+	args := []string{"delete", kind, name}
+	cmd := c.execOcCmd(
+		args,
+		c.namespace,
+		"", // empty as name and selector is not allowed
+	)
+	_, errBytes, err := c.runCmd(cmd)
+	return errBytes, err
+}
+
+func (c *OcClient) execOcCmd(args []string, namespace string, selector string) *exec.Cmd {
+	if len(namespace) > 0 {
+		args = append(args, "--namespace="+namespace)
+	}
+	if len(selector) > 0 {
+		args = append(args, "--selector="+selector)
+	}
+	return c.execPlainOcCmd(args)
+}
+
+func (c *OcClient) execPlainOcCmd(args []string) *exec.Cmd {
+	return c.execCmd(ocBinary, args)
+}
+
+func (c *OcClient) execCmd(executable string, args []string) *exec.Cmd {
+	if verbose {
+		PrintBluef("--> %s\n", executable+" "+strings.Join(args, " "))
+	}
+	return exec.Command(executable, args...)
+}
+
+func (c *OcClient) runCmd(cmd *exec.Cmd) (outBytes, errBytes []byte, err error) {
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	outBytes = stdout.Bytes()
+	errBytes = stderr.Bytes()
+	return outBytes, errBytes, err
+}

--- a/pkg/commands/export.go
+++ b/pkg/commands/export.go
@@ -15,7 +15,8 @@ func Export(exportOptionSets map[string]*cli.ExportOptions) error {
 			return err
 		}
 
-		out, err := openshift.ExportAsTemplateFile(filter, exportOptions)
+		c := cli.NewOcClient(exportOptions.Namespace)
+		out, err := openshift.ExportAsTemplateFile(filter, exportOptions.WithAnnotations, c)
 		if err != nil {
 			return fmt.Errorf(
 				"Could not export %s resources as template: %s",

--- a/pkg/openshift/change.go
+++ b/pkg/openshift/change.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"github.com/opendevstack/tailor/pkg/cli"
+	"github.com/opendevstack/tailor/pkg/utils"
 	"github.com/pmezard/go-difflib/difflib"
 )
 
@@ -24,6 +25,8 @@ var (
 	}
 )
 
+// Change is a description of a drift between current and desired state, and
+// the required patches to bring them back in sync.
 type Change struct {
 	Action       string
 	Kind         string
@@ -39,6 +42,15 @@ type jsonPatch struct {
 	Value interface{} `json:"value,omitempty"`
 }
 
+type jsonPatches []*jsonPatch
+
+func (jp jsonPatch) Pretty() string {
+	var b []byte
+	b, _ = json.MarshalIndent(jp, "", "  ")
+	return string(b)
+}
+
+// NewChange creates a new change for given template/platform item.
 func NewChange(templateItem *ResourceItem, platformItem *ResourceItem, comparison map[string]*jsonPatch) *Change {
 	c := &Change{
 		Kind:         templateItem.Kind,
@@ -65,21 +77,30 @@ func NewChange(templateItem *ResourceItem, platformItem *ResourceItem, compariso
 	return c
 }
 
+// ItemName returns the kind/name of the resource the change relates to.
 func (c *Change) ItemName() string {
 	return kindToShortMapping[c.Kind] + "/" + c.Name
 }
 
-func (c *Change) JsonPatches(pretty bool) string {
+// PrettyJSONPatches prints the JSON patches in pretty form (with indentation).
+func (c *Change) PrettyJSONPatches() string {
 	var b []byte
-	if pretty {
-		b, _ = json.MarshalIndent(c.Patches, "", "  ")
-	} else {
-		b, _ = json.Marshal(c.Patches)
-	}
+	b, _ = json.MarshalIndent(c.Patches, "", "  ")
 	return string(b)
 }
 
+// JSONPatches prints the JSON patches in plain form.
+func (c *Change) JSONPatches() string {
+	var b []byte
+	b, _ = json.Marshal(c.Patches)
+	return string(b)
+}
+
+// Diff returns a unified diff text for the change.
 func (c *Change) Diff() string {
+	if c.isTailorInternalOnly() {
+		return "Only annotations used by Tailor internally differ. Use --diff=json to see details.\n"
+	}
 	diff := difflib.UnifiedDiff{
 		A:        difflib.SplitLines(c.CurrentState),
 		B:        difflib.SplitLines(c.DesiredState),
@@ -96,4 +117,14 @@ func (c *Change) addPatch(patch *jsonPatch) {
 	sort.Slice(c.Patches, func(i, j int) bool {
 		return c.Patches[i].Path < c.Patches[j].Path
 	})
+}
+
+func (c *Change) isTailorInternalOnly() bool {
+	internalPaths := []string{tailorAppliedConfigAnnotationPath, tailorManagedAnnotationPath}
+	for _, p := range c.Patches {
+		if !utils.Includes(internalPaths, p.Path) {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/openshift/list.go
+++ b/pkg/openshift/list.go
@@ -9,17 +9,22 @@ import (
 	"github.com/xeipuuv/gojsonpointer"
 )
 
+// ResourceList is a collection of resources that conform to a filter.
 type ResourceList struct {
 	Filter *ResourceFilter
 	Items  []*ResourceItem
 }
 
+// NewTemplateBasedResourceList assembles a ResourceList from an input that is
+// treated as coming from a local template (desired state).
 func NewTemplateBasedResourceList(filter *ResourceFilter, inputs ...[]byte) (*ResourceList, error) {
 	list := &ResourceList{Filter: filter}
 	err := list.appendItems("template", "/items", inputs...)
 	return list, err
 }
 
+// NewPlatformBasedResourceList assembles a ResourceList from an input that is
+// treated as coming from an OpenShift cluster (current state).
 func NewPlatformBasedResourceList(filter *ResourceFilter, inputs ...[]byte) (*ResourceList, error) {
 	list := &ResourceList{Filter: filter}
 	err := list.appendItems("platform", "/objects", inputs...)

--- a/pkg/openshift/template_test.go
+++ b/pkg/openshift/template_test.go
@@ -2,7 +2,51 @@ package openshift
 
 import (
 	"testing"
+
+	"github.com/opendevstack/tailor/internal/test/helper"
 )
+
+type fakeOcClient struct{}
+
+func (c *fakeOcClient) Export(target string, label string) ([]byte, error) {
+	return helper.ReadFixtureFileOrErr("export/is.yml")
+}
+
+func TestExportAsTemplateFile(t *testing.T) {
+	tests := map[string]struct {
+		goldenTemplateFile string
+		withAnnotations    bool
+	}{
+		"Without annotations": {
+			goldenTemplateFile: "is.yml",
+			withAnnotations:    false,
+		},
+		"With annotations": {
+			goldenTemplateFile: "is-annotation.yml",
+			withAnnotations:    true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			filter, err := NewResourceFilter("is", "", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			actual, err := ExportAsTemplateFile(filter, tc.withAnnotations, &fakeOcClient{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expected := string(helper.ReadGoldenFile(t, "export/"+tc.goldenTemplateFile))
+
+			if expected != actual {
+				t.Fatalf("Expected template:\n%s\nGot template:\n%s", expected, actual)
+			}
+		})
+	}
+}
 
 func TestTemplateContainsTailorNamespaceParam(t *testing.T) {
 	contains, err := templateContainsTailorNamespaceParam("../../internal/test/fixtures/template-with-tailor-namespace-param.yml")


### PR DESCRIPTION
* Hides annotations used by Tailor internally from UI
* Unifies annotation names
* Extracts oc client into separate type
* Avoids drift on empty values such as empty maps or null
* Adds many test cases

Closes #122.
Closes #118.
Closes #107.
Closes #76.

Fixes #112.