### PR TITLE
Use generateName as a fallback name if /metadata/name is not present

### DIFF
--- a/internal/test/fixtures/export/rolebinding-generate-name.yml
+++ b/internal/test/fixtures/export/rolebinding-generate-name.yml
@@ -1,0 +1,20 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  creationTimestamp: null
+  name: tailor
+objects:
+- apiVersion: authorization.openshift.io/v1
+  groupNames: null
+  kind: RoleBinding
+  metadata:
+    creationTimestamp: null
+    generateName: system:image-pusher-
+  roleRef:
+    name: system:image-pusher
+  subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: foo-dev
+  userNames:
+  - system:serviceaccount:foo-dev:default

--- a/internal/test/golden/export/rolebinding-generate-name.yml
+++ b/internal/test/golden/export/rolebinding-generate-name.yml
@@ -1,0 +1,16 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+objects:
+- apiVersion: authorization.openshift.io/v1
+  groupNames: null
+  kind: RoleBinding
+  metadata:
+    generateName: system:image-pusher-
+  roleRef:
+    name: system:image-pusher
+  subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: foo-dev
+  userNames:
+  - system:serviceaccount:foo-dev:default

--- a/pkg/openshift/item.go
+++ b/pkg/openshift/item.go
@@ -122,11 +122,17 @@ func (i *ResourceItem) parseConfig(m map[string]interface{}) error {
 	}
 	i.Kind = kind.(string)
 	namePointer, _ := gojsonpointer.NewJsonPointer("/metadata/name")
-	name, _, err := namePointer.Get(m)
-	if err != nil {
-		return err
+	name, _, noNameErr := namePointer.Get(m)
+	if noNameErr == nil {
+		i.Name = name.(string)
+	} else {
+		generateNamePointer, _ := gojsonpointer.NewJsonPointer("/metadata/generateName")
+		generateName, _, err := generateNamePointer.Get(m)
+		if err != nil {
+			return fmt.Errorf("Resource does not have paths /metadata/name or /metadata/generateName: %s", err)
+		}
+		i.Name = generateName.(string)
 	}
-	i.Name = name.(string)
 
 	// Extract labels
 	labelsPointer, _ := gojsonpointer.NewJsonPointer("/metadata/labels")

--- a/pkg/openshift/template_test.go
+++ b/pkg/openshift/template_test.go
@@ -7,25 +7,34 @@ import (
 )
 
 type mockOcExportClient struct {
-	t *testing.T
+	t       *testing.T
+	fixture string
 }
 
 func (c *mockOcExportClient) Export(target string, label string) ([]byte, error) {
-	return helper.ReadFixtureFile(c.t, "export/is.yml"), nil
+	return helper.ReadFixtureFile(c.t, "export/"+c.fixture), nil
 }
 
 func TestExportAsTemplateFile(t *testing.T) {
 	tests := map[string]struct {
-		goldenTemplateFile string
-		withAnnotations    bool
+		fixture         string
+		goldenTemplate  string
+		withAnnotations bool
 	}{
 		"Without annotations": {
-			goldenTemplateFile: "is.yml",
-			withAnnotations:    false,
+			fixture:         "is.yml",
+			goldenTemplate:  "is.yml",
+			withAnnotations: false,
 		},
 		"With annotations": {
-			goldenTemplateFile: "is-annotation.yml",
-			withAnnotations:    true,
+			fixture:         "is.yml",
+			goldenTemplate:  "is-annotation.yml",
+			withAnnotations: true,
+		},
+		"With generateName": {
+			fixture:         "rolebinding-generate-name.yml",
+			goldenTemplate:  "rolebinding-generate-name.yml",
+			withAnnotations: false,
 		},
 	}
 
@@ -36,16 +45,16 @@ func TestExportAsTemplateFile(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			c := &mockOcExportClient{t}
+			c := &mockOcExportClient{t: t, fixture: tc.fixture}
 			actual, err := ExportAsTemplateFile(filter, tc.withAnnotations, c)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			expected := string(helper.ReadGoldenFile(t, "export/"+tc.goldenTemplateFile))
+			expected := string(helper.ReadGoldenFile(t, "export/"+tc.goldenTemplate))
 
 			if expected != actual {
-				t.Fatalf("Expected template:\n%s\nGot template:\n%s", expected, actual)
+				t.Fatalf("Expected template:\n%s\n--- Got template: --- \n%s", expected, actual)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #135.