### PR TITLE
Remove legacy fields /userNames and /groupNames

### DIFF
--- a/internal/test/fixtures/item-omitted-fields/rolebinding-platform.yml
+++ b/internal/test/fixtures/item-omitted-fields/rolebinding-platform.yml
@@ -1,0 +1,16 @@
+apiVersion: authorization.openshift.io/v1
+groupNames:
+- dedicated-admins
+- system:serviceaccounts:dedicated-admin
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: admin-0
+roleRef:
+  name: admin
+subjects:
+- kind: Group
+  name: dedicated-admins
+- kind: SystemGroup
+  name: system:serviceaccounts:dedicated-admin
+userNames: null

--- a/internal/test/fixtures/item-omitted-fields/rolebinding-template.yml
+++ b/internal/test/fixtures/item-omitted-fields/rolebinding-template.yml
@@ -1,0 +1,13 @@
+apiVersion: authorization.openshift.io/v1
+groupNames: null
+kind: RoleBinding
+metadata:
+  name: admin-0
+roleRef:
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: jenkins
+  namespace: foo-cd
+userNames:
+- system:serviceaccount:foo-cd:jenkins

--- a/internal/test/golden/export/rolebinding-generate-name.yml
+++ b/internal/test/golden/export/rolebinding-generate-name.yml
@@ -2,7 +2,6 @@ apiVersion: template.openshift.io/v1
 kind: Template
 objects:
 - apiVersion: authorization.openshift.io/v1
-  groupNames: null
   kind: RoleBinding
   metadata:
     generateName: system:image-pusher-
@@ -12,5 +11,3 @@ objects:
   - kind: ServiceAccount
     name: default
     namespace: foo-dev
-  userNames:
-  - system:serviceaccount:foo-dev:default

--- a/internal/test/golden/item-omitted-fields/rolebinding-changed.txt
+++ b/internal/test/golden/item-omitted-fields/rolebinding-changed.txt
@@ -1,0 +1,13 @@
+--- Current State (OpenShift cluster)
++++ Desired State (Processed template)
+@@ -5,8 +5,7 @@
+ roleRef:
+   name: admin
+ subjects:
+-- kind: Group
+-  name: dedicated-admins
+-- kind: SystemGroup
+-  name: system:serviceaccounts:dedicated-admin
++- kind: ServiceAccount
++  name: jenkins
++  namespace: foo-cd

--- a/pkg/openshift/item.go
+++ b/pkg/openshift/item.go
@@ -30,6 +30,8 @@ var (
 		"/status",
 		"/spec/volumeName",
 		"/spec/template/metadata/creationTimestamp",
+		"/groupNames",
+		"/userNames",
 	}
 	platformManagedRegexFields = []string{
 		"^/spec/triggers/[0-9]*/imageChangeParams/lastTriggeredImage",
@@ -246,9 +248,13 @@ func (i *ResourceItem) parseConfig(m map[string]interface{}) error {
 	}
 
 	// Remove platform-managed simple fields
+	legacyFields := []string{"/userNames", "/groupNames"}
 	for _, p := range platformManagedSimpleFields {
 		deletePointer, _ := gojsonpointer.NewJsonPointer(p)
 		_, _ = deletePointer.Delete(m)
+		if utils.Includes(legacyFields, p) {
+			cli.VerboseMsg("Removed", p, "which is used for legacy clients, but not supported by Tailor")
+		}
 	}
 
 	i.Config = m


### PR DESCRIPTION
They are added only for legacy clients but cause some issues with
Tailor, especially because they might be added with a value of `null`
instead of an empty array.

Fixes #140.