### PR TITLE
Rename status to diff and update to apply

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL = /bin/bash
 .ONESHELL:
 .SHELLFLAGS := -eu -o pipefail -c
 .DELETE_ON_ERROR:

--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,51 @@
+.ONESHELL:
+.SHELLFLAGS := -eu -o pipefail -c
+.DELETE_ON_ERROR:
+MAKEFLAGS += --warn-undefined-variables
+MAKEFLAGS += --no-builtin-rules
 
-.PHONY: test test-unit test-e2e imports fmt lint install build build-darwin build-linux build-windows
 
 test-unit: imports
 	@(go list ./... | grep -v "vendor/" | grep -v "e2e" | xargs -n1 go test -cover)
+.PHONY: test-unit
 
 test-e2e: imports internal/test/e2e/tailor-test
 	@(go test -v -cover github.com/opendevstack/tailor/internal/test/e2e)
+.PHONY: test-e2e
 
 test: test-unit test-e2e
+.PHONY: test
 
 imports:
 	@(goimports -w .)
+.PHONY: imports
 
 fmt:
 	@(gofmt -w .)
+.PHONY: fmt
 
 lint:
 	@(go mod download && golangci-lint run)
+.PHONY: lint
 
 install: imports
 	@(cd cmd/tailor && go install)
+.PHONY: install
 
 build: imports build-linux build-darwin build-windows
+.PHONY: build
 
 build-linux: imports
 	cd cmd/tailor && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o tailor-linux-amd64
+.PHONY: build-linux
 
 build-darwin: imports
 	cd cmd/tailor && GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o tailor-darwin-amd64
+.PHONY: build-darwin
 
 build-windows: imports
 	cd cmd/tailor && GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o tailor-windows-amd64.exe
+.PHONY: build-windows
 
 internal/test/e2e/tailor-test: cmd/tailor/main.go go.mod go.sum pkg/cli/* pkg/commands/* pkg/openshift/* pkg/utils/*
 	@(echo "Generating E2E test binary ...")

--- a/README.md
+++ b/README.md
@@ -40,22 +40,22 @@ chmod +x tailor-windows-amd64.exe && mv tailor-windows-amd64.exe /mingw64/bin/ta
 
 ## Usage
 
-There are three main commands: `export`, `status` and `update`.
+There are three main commands: `export`, `diff` and `apply`.
 
 ### `export`
 Export configuration of resources found in an OpenShift namespace to a cleaned
 YAML template, which is written to `STDOUT`.
 
-### `status`
+### `diff`
 Show drift between the current state in the OpenShift cluster and the desired
 state in the YAML templates. There are three main aspects to this:
-1. By default, all resource types are compared, but you can limit to specific ones, e.g. `status pvc,dc`.
-2. The desired state is computed by processing the local YAML templates. It is possible to pass `--labels`, `--param` and `--param-file` to the `status` command to influence the generated config. Those 3 flags are passed as-is to the underlying `oc process` command. As Tailor allows you to work with multiple templates, there is an additional `--param-dir="<namespace>|."` flag, which you can use to point to a folder containing param files corresponding to each template (e.g. `foo.env` for template `foo.yml`).
+1. By default, all resource types are compared, but you can limit to specific ones, e.g. `diff pvc,dc`.
+2. The desired state is computed by processing the local YAML templates. It is possible to pass `--labels`, `--param` and `--param-file` to the `diff` command to influence the generated config. Those 3 flags are passed as-is to the underlying `oc process` command. As Tailor allows you to work with multiple templates, there is an additional `--param-dir="<namespace>|."` flag, which you can use to point to a folder containing param files corresponding to each template (e.g. `foo.env` for template `foo.yml`).
 3. In order to calculate drift correctly, the whole OpenShift namespace is compared against your configuration. If you want to compare a subset only (e.g. all resources related to one microservice), it is possible to narrow the scope by passing `--selector/-l`, e.g. `-l app=foo` (multiple labels are comma-separated, and need to apply all). Further, you can specify an individual resource, e.g. `dc/foo`.
 
 ### `update`
-This command will compare current vs. desired state exactly like `status` does,
-but if any drift is detected, it asks to update the OpenShift namespace with your desired state. A subsequent run of either `status` or `update` should show no drift.
+This command will compare current vs. desired state exactly like `diff` does,
+but if any drift is detected, it asks to apply the OpenShift namespace with your desired state. A subsequent run of either `diff` or `apply` should show no drift.
 
 ### General Usage Notes
 All commands depend on a current OpenShift session and accept a `--namespace` flag (if none is given, the current one is used). To help with debugging (e.g. to see the commands which are executed in the background), use `--verbose`. More options can be displayed with `tailor help`.
@@ -74,7 +74,7 @@ processing templates, it merges `*.env` and `*.env.enc` files together. In order
 to create and edit `*.env.enc` files, Tailor offers an `edit` command.
 
 `secrets edit foo.env.enc` opens a terminal editor, in which you can enter the
-params in plain, e.g. `PASSWORD=s3cr3t`. When saved, every aram value will be encrypted for all public keys in `--public-key-dir="public-keys|."`. To read a file with encrypted params (e.g. to edit the secrets or compare the status between desired and current state), you need your private key available at `--private-key="private.key"`.
+params in plain, e.g. `PASSWORD=s3cr3t`. When saved, every aram value will be encrypted for all public keys in `--public-key-dir="public-keys|."`. To read a file with encrypted params (e.g. to edit the secrets or compare the diff between desired and current state), you need your private key available at `--private-key="private.key"`.
 
 When a public key is added or removed, it is required to run `secrets re-encrypt`.
 This decrypts all params in `*.env.enc` files and writes them again using the provided public keys.

--- a/cmd/tailor/main.go
+++ b/cmd/tailor/main.go
@@ -85,91 +85,91 @@ var (
 		"Show version",
 	)
 
-	statusCommand = app.Command(
-		"status",
+	diffCommand = app.Command(
+		"diff",
 		"Show diff between remote and local",
-	)
-	statusLabelsFlag = statusCommand.Flag(
+	).Alias("status")
+	diffLabelsFlag = diffCommand.Flag(
 		"labels",
 		"Label to set in all resources for this template.",
 	).String()
-	statusParamFlag = statusCommand.Flag(
+	diffParamFlag = diffCommand.Flag(
 		"param",
 		"Specify a key-value pair (eg. -p FOO=BAR) to set/override a parameter value in the template.",
 	).Strings()
-	statusParamFileFlag = statusCommand.Flag(
+	diffParamFileFlag = diffCommand.Flag(
 		"param-file",
 		"File(s) containing template parameter values to set/override in the template.",
 	).Strings()
-	statusDiffFlag = statusCommand.Flag(
+	diffDiffFlag = diffCommand.Flag(
 		"diff",
 		"Whether to show textual diff (\"text\") or JSON patches (\"json\"). JSON patches might show secret values in clear text.",
 	).Default("text").String()
-	statusIgnorePathFlag = statusCommand.Flag(
+	diffIgnorePathFlag = diffCommand.Flag(
 		"ignore-path",
 		"Path(s) per kind/name to ignore (e.g. because they are externally modified) in RFC 6901 format.",
 	).PlaceHolder("bc:foobar:/spec/output/to/name").Strings()
-	statusIgnoreUnknownParametersFlag = statusCommand.Flag(
+	diffIgnoreUnknownParametersFlag = diffCommand.Flag(
 		"ignore-unknown-parameters",
 		"If true, will not stop processing if a provided parameter does not exist in the template.",
 	).Bool()
-	statusUpsertOnlyFlag = statusCommand.Flag(
+	diffUpsertOnlyFlag = diffCommand.Flag(
 		"upsert-only",
 		"Don't delete resource, only create / update.",
 	).Short('u').Bool()
-	statusAllowRecreateFlag = statusCommand.Flag(
+	diffAllowRecreateFlag = diffCommand.Flag(
 		"allow-recreate",
 		"Allow to recreate the whole resource when an immutable field is changed.",
 	).Bool()
-	statusRevealSecretsFlag = statusCommand.Flag(
+	diffRevealSecretsFlag = diffCommand.Flag(
 		"reveal-secrets",
 		"Reveal drift of Secret resources (might show secret values in clear text).",
 	).Bool()
-	statusResourceArg = statusCommand.Arg(
+	diffResourceArg = diffCommand.Arg(
 		"resource", "Remote resource (defaults to all)",
 	).String()
 
-	updateCommand = app.Command(
-		"update",
+	applyCommand = app.Command(
+		"apply",
 		"Update remote with local",
-	)
-	updateLabelsFlag = updateCommand.Flag(
+	).Alias("update")
+	applyLabelsFlag = applyCommand.Flag(
 		"labels",
 		"Label to set in all resources for this template.",
 	).String()
-	updateParamFlag = updateCommand.Flag(
+	applyParamFlag = applyCommand.Flag(
 		"param",
 		"Specify a key-value pair (eg. -p FOO=BAR) to set/override a parameter value in the template.",
 	).Strings()
-	updateParamFileFlag = updateCommand.Flag(
+	applyParamFileFlag = applyCommand.Flag(
 		"param-file",
 		"File(s) containing template parameter values to set/override in the template.",
 	).Strings()
-	updateDiffFlag = updateCommand.Flag(
+	applyDiffFlag = applyCommand.Flag(
 		"diff",
 		"Whether to show textual diff (\"text\") or JSON patches (\"json\"). JSON patches might show secret values in clear text.",
 	).Default("text").String()
-	updateIgnorePathFlag = updateCommand.Flag(
+	applyIgnorePathFlag = applyCommand.Flag(
 		"ignore-path",
 		"Path(s) per kind to ignore (e.g. because they are externally modified) in RFC 6901 format.",
 	).PlaceHolder("bc:foobar:/spec/output/to/name").Strings()
-	updateIgnoreUnknownParametersFlag = updateCommand.Flag(
+	applyIgnoreUnknownParametersFlag = applyCommand.Flag(
 		"ignore-unknown-parameters",
 		"If true, will not stop processing if a provided parameter does not exist in the template.",
 	).Bool()
-	updateUpsertOnlyFlag = updateCommand.Flag(
+	applyUpsertOnlyFlag = applyCommand.Flag(
 		"upsert-only",
-		"Don't delete resource, only create / update.",
+		"Don't delete resource, only create / apply.",
 	).Short('u').Bool()
-	updateAllowRecreateFlag = updateCommand.Flag(
+	applyAllowRecreateFlag = applyCommand.Flag(
 		"allow-recreate",
 		"Allow to recreate the whole resource when an immutable field is changed.",
 	).Bool()
-	updateRevealSecretsFlag = updateCommand.Flag(
+	applyRevealSecretsFlag = applyCommand.Flag(
 		"reveal-secrets",
 		"Reveal drift of Secret resources (might show secret values in clear text).",
 	).Bool()
-	updateResourceArg = updateCommand.Arg(
+	applyResourceArg = applyCommand.Arg(
 		"resource", "Remote resource (defaults to all)",
 	).String()
 
@@ -328,7 +328,7 @@ func main() {
 			log.Fatalf("Failed to generate keypair: %s.", err)
 		}
 
-	case statusCommand.FullCommand():
+	case diffCommand.FullCommand():
 		optionSets := map[string]*cli.CompareOptions{}
 		for _, contextDir := range globalOptions.ContextDirs {
 			opt, err := cli.NewCompareOptions(
@@ -342,16 +342,16 @@ func main() {
 				*publicKeyDirFlag,
 				*privateKeyFlag,
 				*passphraseFlag,
-				*statusLabelsFlag,
-				*statusParamFlag,
-				*statusParamFileFlag,
-				*statusDiffFlag,
-				*statusIgnorePathFlag,
-				*statusIgnoreUnknownParametersFlag,
-				*statusUpsertOnlyFlag,
-				*statusAllowRecreateFlag,
-				*statusRevealSecretsFlag,
-				*statusResourceArg,
+				*diffLabelsFlag,
+				*diffParamFlag,
+				*diffParamFileFlag,
+				*diffDiffFlag,
+				*diffIgnorePathFlag,
+				*diffIgnoreUnknownParametersFlag,
+				*diffUpsertOnlyFlag,
+				*diffAllowRecreateFlag,
+				*diffRevealSecretsFlag,
+				*diffResourceArg,
 			)
 			if err != nil {
 				log.Fatalln("Options could not be processed:", err)
@@ -359,15 +359,15 @@ func main() {
 			optionSets[contextDir] = opt
 		}
 
-		updateRequired, err := commands.Status(optionSets)
+		driftDectected, err := commands.Diff(optionSets)
 		if err != nil {
 			log.Fatalln(err)
 		}
-		if updateRequired {
+		if driftDectected {
 			os.Exit(3)
 		}
 
-	case updateCommand.FullCommand():
+	case applyCommand.FullCommand():
 		optionSets := map[string]*cli.CompareOptions{}
 		for _, contextDir := range globalOptions.ContextDirs {
 			opt, err := cli.NewCompareOptions(
@@ -381,16 +381,16 @@ func main() {
 				*publicKeyDirFlag,
 				*privateKeyFlag,
 				*passphraseFlag,
-				*updateLabelsFlag,
-				*updateParamFlag,
-				*updateParamFileFlag,
-				*updateDiffFlag,
-				*updateIgnorePathFlag,
-				*updateIgnoreUnknownParametersFlag,
-				*updateUpsertOnlyFlag,
-				*updateAllowRecreateFlag,
-				*updateRevealSecretsFlag,
-				*updateResourceArg,
+				*applyLabelsFlag,
+				*applyParamFlag,
+				*applyParamFileFlag,
+				*applyDiffFlag,
+				*applyIgnorePathFlag,
+				*applyIgnoreUnknownParametersFlag,
+				*applyUpsertOnlyFlag,
+				*applyAllowRecreateFlag,
+				*applyRevealSecretsFlag,
+				*applyResourceArg,
 			)
 			if err != nil {
 				log.Fatalln("Options could not be processed:", err)
@@ -398,7 +398,7 @@ func main() {
 			optionSets[contextDir] = opt
 		}
 
-		err = commands.Update(globalOptions.NonInteractive, optionSets)
+		err = commands.Apply(globalOptions.NonInteractive, optionSets)
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/cmd/tailor/main.go
+++ b/cmd/tailor/main.go
@@ -101,8 +101,8 @@ var (
 		"param-file",
 		"File(s) containing template parameter values to set/override in the template.",
 	).Strings()
-	diffDiffFlag = diffCommand.Flag(
-		"diff",
+	diffFormatFlag = diffCommand.Flag(
+		"format",
 		"Whether to show textual diff (\"text\") or JSON patches (\"json\"). JSON patches might show secret values in clear text.",
 	).Default("text").String()
 	diffIgnorePathFlag = diffCommand.Flag(
@@ -345,7 +345,7 @@ func main() {
 				*diffLabelsFlag,
 				*diffParamFlag,
 				*diffParamFileFlag,
-				*diffDiffFlag,
+				*diffFormatFlag,
 				*diffIgnorePathFlag,
 				*diffIgnoreUnknownParametersFlag,
 				*diffUpsertOnlyFlag,

--- a/internal/test/e2e/partial_test.go
+++ b/internal/test/e2e/partial_test.go
@@ -15,9 +15,9 @@ func TestPartialScope(t *testing.T) {
 
 	tailorBinary := getTailorBinary()
 
-	export(t, tailorBinary)
+	runExport(t, tailorBinary)
 
-	statusWithNoExpectedDrift(t, tailorBinary)
+	diffWithNoExpectedDrift(t, tailorBinary)
 
 	fmt.Println("Create new template with label app=foo")
 	fooBytes := []byte(
@@ -93,8 +93,8 @@ objects:
 		t.Fatalf("Fail to write file bar-template.yml: %s", err)
 	}
 
-	update(t, tailorBinary)
-	statusWithNoExpectedDrift(t, tailorBinary)
+	runApply(t, tailorBinary)
+	diffWithNoExpectedDrift(t, tailorBinary)
 
 	partialStatusWithNoExpectedDrift(t, tailorBinary, "app=foo")
 	partialStatusWithNoExpectedDrift(t, tailorBinary, "app=bar")
@@ -108,7 +108,7 @@ objects:
 	}
 
 	// Status for app=foo -> expected to have drift (updated resource)
-	cmd := exec.Command(tailorBinary, []string{"status", "--force", "-l", "app=foo"}...)
+	cmd := exec.Command(tailorBinary, []string{"diff", "--force", "-l", "app=foo"}...)
 	out, err := cmd.CombinedOutput()
 	if err == nil {
 		t.Fatalf("Status command should have exited with 3")
@@ -131,7 +131,7 @@ objects:
 }
 
 func partialStatusWithNoExpectedDrift(t *testing.T, tailorBinary string, label string) {
-	cmd := exec.Command(tailorBinary, []string{"status", "--force", "-l", label}...)
+	cmd := exec.Command(tailorBinary, []string{"diff", "--force", "-l", label}...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Could not get status for %s in test project", label)

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -43,7 +43,7 @@ type CompareOptions struct {
 	Labels                  string
 	Params                  []string
 	ParamFiles              []string
-	Diff                    string
+	Format                  string
 	IgnorePaths             []string
 	IgnoreUnknownParameters bool
 	UpsertOnly              bool
@@ -158,7 +158,7 @@ func NewCompareOptions(
 	labelsFlag string,
 	paramFlag []string,
 	paramFileFlag []string,
-	diffFlag string,
+	formatFlag string,
 	ignorePathFlag []string,
 	ignoreUnknownParametersFlag bool,
 	upsertOnlyFlag bool,
@@ -263,10 +263,10 @@ func NewCompareOptions(
 		o.ParamFiles = strings.Split(val, ",")
 	}
 
-	if len(diffFlag) > 0 {
-		o.Diff = diffFlag
+	if len(formatFlag) > 0 {
+		o.Format = formatFlag
 	} else if val, ok := fileFlags["diff"]; ok {
-		o.Diff = val
+		o.Format = val
 	}
 
 	if len(ignorePathFlag) > 0 {
@@ -491,7 +491,7 @@ func (o *CompareOptions) check() error {
 		}
 	}
 
-	if o.Diff != "text" && o.Diff != "json" {
+	if o.Format != "text" && o.Format != "json" {
 		return errors.New("--diff must be either text or json")
 	}
 	if strings.Contains(o.Resource, "/") && len(o.Selector) > 0 {

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -143,7 +143,7 @@ func NewGlobalOptions(
 	return o, o.check(clusterRequired)
 }
 
-// NewCompareOptions returns new options for the status/update command based on file/flags.
+// NewCompareOptions returns new options for the diff/apply command based on file/flags.
 func NewCompareOptions(
 	globalOptions *GlobalOptions,
 	contextDir string,

--- a/pkg/commands/apply.go
+++ b/pkg/commands/apply.go
@@ -8,9 +8,9 @@ import (
 	"github.com/opendevstack/tailor/pkg/openshift"
 )
 
-// Update prints the drift between desired and current state to STDOUT.
+// Apply prints the drift between desired and current state to STDOUT.
 // If there is any, it asks for confirmation and applies the changeset.
-func Update(nonInteractive bool, compareOptionSets map[string]*cli.CompareOptions) error {
+func Apply(nonInteractive bool, compareOptionSets map[string]*cli.CompareOptions) error {
 	updateRequired, changesets, err := calculateChangesets(compareOptionSets)
 	if err != nil {
 		return err
@@ -21,7 +21,7 @@ func Update(nonInteractive bool, compareOptionSets map[string]*cli.CompareOption
 			for contextDir, compareOptions := range compareOptionSets {
 				err = apply(compareOptions, changesets[contextDir])
 				if err != nil {
-					return fmt.Errorf("Update aborted: %s", err)
+					return fmt.Errorf("Apply aborted: %s", err)
 				}
 			}
 		} else {
@@ -31,7 +31,7 @@ func Update(nonInteractive bool, compareOptionSets map[string]*cli.CompareOption
 				for contextDir, compareOptions := range compareOptionSets {
 					err = apply(compareOptions, changesets[contextDir])
 					if err != nil {
-						return fmt.Errorf("Update aborted: %s", err)
+						return fmt.Errorf("Apply aborted: %s", err)
 					}
 				}
 			}

--- a/pkg/commands/diff.go
+++ b/pkg/commands/diff.go
@@ -162,7 +162,7 @@ func calculateChangeset(compareOptions *cli.CompareOptions, ocClient cli.ClientP
 		compareOptions.UpsertOnly,
 		compareOptions.AllowRecreate,
 		compareOptions.RevealSecrets,
-		compareOptions.Diff,
+		compareOptions.Format,
 		compareOptions.IgnorePaths,
 	)
 	if err != nil {
@@ -172,7 +172,7 @@ func calculateChangeset(compareOptions *cli.CompareOptions, ocClient cli.ClientP
 	return updateRequired, changeset, nil
 }
 
-func compare(remoteResourceList *openshift.ResourceList, localResourceList *openshift.ResourceList, upsertOnly bool, allowRecreate bool, revealSecrets bool, diff string, ignorePaths []string) (*openshift.Changeset, error) {
+func compare(remoteResourceList *openshift.ResourceList, localResourceList *openshift.ResourceList, upsertOnly bool, allowRecreate bool, revealSecrets bool, format string, ignorePaths []string) (*openshift.Changeset, error) {
 	changeset, err := openshift.NewChangeset(remoteResourceList, localResourceList, upsertOnly, allowRecreate, ignorePaths)
 	if err != nil {
 		return changeset, err
@@ -194,7 +194,7 @@ func compare(remoteResourceList *openshift.ResourceList, localResourceList *open
 
 	for _, change := range changeset.Update {
 		cli.PrintYellowf("~ %s to update\n", change.ItemName())
-		if diff == "text" {
+		if format == "text" {
 			fmt.Print(change.Diff(revealSecrets))
 		} else {
 			fmt.Println(change.PrettyJSONPatches())

--- a/pkg/commands/diff.go
+++ b/pkg/commands/diff.go
@@ -9,8 +9,8 @@ import (
 	"github.com/opendevstack/tailor/pkg/openshift"
 )
 
-// Status prints the drift between desired and current state to STDOUT.
-func Status(compareOptionSets map[string]*cli.CompareOptions) (bool, error) {
+// Diff prints the drift between desired and current state to STDOUT.
+func Diff(compareOptionSets map[string]*cli.CompareOptions) (bool, error) {
 	updateRequired, _, err := calculateChangesets(compareOptionSets)
 	return updateRequired, err
 }


### PR DESCRIPTION
Aligns the naming with `oc` and `kubectl` commands.

Changes:

* `status` is now `diff`
* `update` is now `apply`
* `--diff` is now `--format`