### PR TITLE
Use "oc apply" instead of generating patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,26 +84,6 @@ the param values so that you can see the clear text secrets.
 
 Finally, to ease PGP management, `secrets generate-key john.doe@domain.com` generates a PGP keypair, writing the public key to `john-doe.key` (which should be committed) and the private key to `private.key` (which MUST NOT be committed).
 
-### Working with annotations
-
-Annotations on OpenShift resources provide a means for tools to add additional
-information to resources. Often, those annotations cannot be known by the
-template author. Therefore, Tailor does not calculate drift for annotations by
-default.
-
-If you wish to control annotations via Tailor, you can use
-`export --with-annotations` to include annotations in the export, or, when you
-author templates, by simply adding individual annotations to your templates.
-
-Tailor will treat any annotations present in templates as being under Tailor's
-control, therefore e.g. changes in the annotation values will be seen as drift.
-
-To achieve this, Tailor itself uses an annotation to keep track of the
-annotation it controls. This annotation (and another annotation preserving the
-applied configuration for fields that are modified by OpenShift such as image
-reference) is hidden by default from drift reports but can be seen using the
-JSON patches diff view (`--diff=json`). 
-
 
 ### Permissions
 

--- a/cmd/tailor/main.go
+++ b/cmd/tailor/main.go
@@ -101,10 +101,6 @@ var (
 		"param-file",
 		"File(s) containing template parameter values to set/override in the template.",
 	).Strings()
-	diffFormatFlag = diffCommand.Flag(
-		"format",
-		"Whether to show textual diff (\"text\") or JSON patches (\"json\"). JSON patches might show secret values in clear text.",
-	).Default("text").String()
 	diffIgnorePathFlag = diffCommand.Flag(
 		"ignore-path",
 		"DEPRECATED! Use --preserve instead.",
@@ -153,10 +149,6 @@ var (
 		"param-file",
 		"File(s) containing template parameter values to set/override in the template.",
 	).Strings()
-	applyFormatFlag = applyCommand.Flag(
-		"format",
-		"Whether to show textual diff (\"text\") or JSON patches (\"json\"). JSON patches might show secret values in clear text.",
-	).Default("text").String()
 	applyIgnorePathFlag = applyCommand.Flag(
 		"ignore-path",
 		"DEPRECATED! Use --preserve instead.",
@@ -363,7 +355,6 @@ func main() {
 				*diffLabelsFlag,
 				*diffParamFlag,
 				*diffParamFileFlag,
-				*diffFormatFlag,
 				preservePathFlag,
 				*diffPreserveImmutableFieldsFlag,
 				*diffIgnoreUnknownParametersFlag,
@@ -405,7 +396,6 @@ func main() {
 				*applyLabelsFlag,
 				*applyParamFlag,
 				*applyParamFileFlag,
-				*applyFormatFlag,
 				preservePathFlag,
 				*applyPreserveImmutableFieldsFlag,
 				*applyIgnoreUnknownParametersFlag,

--- a/internal/test/fixtures/empty-values/bc-platform.yml
+++ b/internal/test/fixtures/empty-values/bc-platform.yml
@@ -7,7 +7,6 @@ metadata:
   name: foo
 spec:
   failedBuildsHistoryLimit: 5
-  nodeSelector: null
   output:
     to:
       kind: ImageStreamTag

--- a/internal/test/fixtures/export/is.yml
+++ b/internal/test/fixtures/export/is.yml
@@ -10,7 +10,6 @@ objects:
     annotations:
       description: Keeps track of changes in the application image
       openshift.io/image.dockerRepositoryCheck: 2018-08-07T12:32:24Z
-      tailor.opendevstack.org/managed-annotations: description
     creationTimestamp: null
     generation: 560
     labels:

--- a/internal/test/fixtures/item-applied-config/dc-platform-annotation-applied.yml
+++ b/internal/test/fixtures/item-applied-config/dc-platform-annotation-applied.yml
@@ -3,7 +3,8 @@ kind: DeploymentConfig
 metadata:
   name: foo
   annotations:
-    tailor.opendevstack.org/applied-config: '{"/spec/template/spec/containers/0/image": "bar/foo:latest"}'
+    kubectl.kubernetes.io/last-applied-configuration: >
+      {"apiVersion":"v1","kind":"DeploymentConfig","metadata":{"name":"foo"},"spec":{"template":{"spec":{"containers":[{"image":"bar/foo:latest"}]}}}}
 spec:
   replicas: 1
   selector:

--- a/internal/test/fixtures/item-managed-annotations/is-platform-annotation.yml
+++ b/internal/test/fixtures/item-managed-annotations/is-platform-annotation.yml
@@ -4,7 +4,8 @@ metadata:
   name: foo
   annotations:
     bar: baz
-    tailor.opendevstack.org/managed-annotations: bar
+    kubectl.kubernetes.io/last-applied-configuration: >
+      {"apiVersion":"v1","kind":"ImageStream","metadata":{"annotations":{"bar":"baz"}}}
 spec:
   dockerImageRepository: foo
   lookupPolicy:

--- a/internal/test/golden/desired-state/dc-annotation.yml
+++ b/internal/test/golden/desired-state/dc-annotation.yml
@@ -3,8 +3,6 @@ kind: DeploymentConfig
 metadata:
   annotations:
     baz: qux
-    tailor.opendevstack.org/applied-config: '{"/spec/template/spec/containers/0/image":"foo-test/bar:latest"}'
-    tailor.opendevstack.org/managed-annotations: baz
   labels:
     app: foo-bar
   name: bar

--- a/internal/test/golden/desired-state/dc.yml
+++ b/internal/test/golden/desired-state/dc.yml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: DeploymentConfig
 metadata:
-  annotations:
-    tailor.opendevstack.org/applied-config: '{"/spec/template/spec/containers/0/image":"foo-test/bar:latest"}'
   labels:
     app: foo-bar
   name: bar

--- a/internal/test/golden/desired-state/is-annotation.yml
+++ b/internal/test/golden/desired-state/is-annotation.yml
@@ -3,7 +3,6 @@ kind: ImageStream
 metadata:
   annotations:
     foo: bar
-    tailor.opendevstack.org/managed-annotations: foo
   name: foo
 spec:
   dockerImageRepository: foo

--- a/pkg/cli/oc_client.go
+++ b/pkg/cli/oc_client.go
@@ -24,19 +24,14 @@ type OcClientExporter interface {
 	Export(target string, label string) ([]byte, error)
 }
 
-// OcClientPatcher allows to patch a resource.
-type OcClientPatcher interface {
-	Patch(target string, patches string) ([]byte, error)
-}
-
 // OcClientDeleter allows to delete a resource.
 type OcClientDeleter interface {
 	Delete(kind string, name string) ([]byte, error)
 }
 
-// OcClientCreator allows to create a resource.
-type OcClientCreator interface {
-	Create(config string, selector string) ([]byte, error)
+// OcClientApplier allows to create a resource.
+type OcClientApplier interface {
+	Apply(config string, selector string) ([]byte, error)
 }
 
 // OcClientVersioner allows to retrieve the OpenShift version..
@@ -118,21 +113,9 @@ func (c *OcClient) Export(target string, label string) ([]byte, error) {
 	return outBytes, nil
 }
 
-// Patch applies the given patch on the target.
-func (c *OcClient) Patch(target string, patches string) ([]byte, error) {
-	args := []string{"patch", target, "--type=json", "--patch", patches}
-	cmd := c.execOcCmd(
-		args,
-		c.namespace,
-		"", // empty as name and selector is not allowed
-	)
-	_, errBytes, err := c.runCmd(cmd)
-	return errBytes, err
-}
-
-// Create creates given resource configuration.
-func (c *OcClient) Create(config string, selector string) ([]byte, error) {
-	args := []string{"create", "-f", "-"}
+// Apply applies given resource configuration.
+func (c *OcClient) Apply(config string, selector string) ([]byte, error) {
+	args := []string{"apply", "-f", "-"}
 	cmd := c.execOcCmd(
 		args,
 		c.namespace,

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -43,7 +43,6 @@ type CompareOptions struct {
 	Labels                  string
 	Params                  []string
 	ParamFiles              []string
-	Format                  string
 	PreservePaths           []string
 	PreserveImmutableFields bool
 	IgnoreUnknownParameters bool
@@ -159,7 +158,6 @@ func NewCompareOptions(
 	labelsFlag string,
 	paramFlag []string,
 	paramFileFlag []string,
-	formatFlag string,
 	preserveFlag []string,
 	preserveImmutableFieldsFlag bool,
 	ignoreUnknownParametersFlag bool,
@@ -263,12 +261,6 @@ func NewCompareOptions(
 		o.ParamFiles = paramFileFlag
 	} else if val, ok := fileFlags["param-file"]; ok {
 		o.ParamFiles = strings.Split(val, ",")
-	}
-
-	if len(formatFlag) > 0 {
-		o.Format = formatFlag
-	} else if val, ok := fileFlags["diff"]; ok {
-		o.Format = val
 	}
 
 	if len(preserveFlag) > 0 {
@@ -501,9 +493,6 @@ func (o *CompareOptions) check() error {
 		}
 	}
 
-	if o.Format != "text" && o.Format != "json" {
-		return errors.New("--diff must be either text or json")
-	}
 	if strings.Contains(o.Resource, "/") && len(o.Selector) > 0 {
 		DebugMsg("Ignoring selector", o.Selector, "as resource is given")
 		o.Selector = ""

--- a/pkg/commands/apply.go
+++ b/pkg/commands/apply.go
@@ -58,7 +58,7 @@ func apply(compareOptions *cli.CompareOptions, c *openshift.Changeset) error {
 	)
 
 	for _, change := range c.Create {
-		err := ocCreate(change, compareOptions, ocClient)
+		err := ocApply("Creating", change, compareOptions, ocClient)
 		if err != nil {
 			return err
 		}
@@ -72,7 +72,7 @@ func apply(compareOptions *cli.CompareOptions, c *openshift.Changeset) error {
 	}
 
 	for _, change := range c.Update {
-		err := ocPatch(change, compareOptions, ocClient)
+		err := ocApply("Updating", change, compareOptions, ocClient)
 		if err != nil {
 			return err
 		}
@@ -93,9 +93,9 @@ func ocDelete(change *openshift.Change, compareOptions *cli.CompareOptions, ocCl
 	return nil
 }
 
-func ocCreate(change *openshift.Change, compareOptions *cli.CompareOptions, ocClient cli.OcClientCreator) error {
-	fmt.Printf("Creating %s ... ", change.ItemName())
-	errBytes, err := ocClient.Create(change.DesiredState, compareOptions.Selector)
+func ocApply(label string, change *openshift.Change, compareOptions *cli.CompareOptions, ocClient cli.OcClientApplier) error {
+	fmt.Printf("%s %s ... ", label, change.ItemName())
+	errBytes, err := ocClient.Apply(change.DesiredState, compareOptions.Selector)
 	if err == nil {
 		fmt.Println("done")
 	} else {
@@ -103,17 +103,5 @@ func ocCreate(change *openshift.Change, compareOptions *cli.CompareOptions, ocCl
 		return errors.New(string(errBytes))
 	}
 
-	return nil
-}
-
-func ocPatch(change *openshift.Change, compareOptions *cli.CompareOptions, ocClient cli.OcClientPatcher) error {
-	fmt.Printf("Patching %s ... ", change.ItemName())
-	errBytes, err := ocClient.Patch(change.ItemName(), change.JSONPatches())
-	if err == nil {
-		fmt.Println("done")
-	} else {
-		fmt.Println("failed")
-		return errors.New(string(errBytes))
-	}
 	return nil
 }

--- a/pkg/commands/diff.go
+++ b/pkg/commands/diff.go
@@ -162,7 +162,6 @@ func calculateChangeset(compareOptions *cli.CompareOptions, ocClient cli.ClientP
 		compareOptions.UpsertOnly,
 		compareOptions.AllowRecreate,
 		compareOptions.RevealSecrets,
-		compareOptions.Format,
 		compareOptions.PathsToPreserve(),
 	)
 	if err != nil {
@@ -172,7 +171,7 @@ func calculateChangeset(compareOptions *cli.CompareOptions, ocClient cli.ClientP
 	return updateRequired, changeset, nil
 }
 
-func compare(remoteResourceList *openshift.ResourceList, localResourceList *openshift.ResourceList, upsertOnly bool, allowRecreate bool, revealSecrets bool, format string, preservePaths []string) (*openshift.Changeset, error) {
+func compare(remoteResourceList *openshift.ResourceList, localResourceList *openshift.ResourceList, upsertOnly bool, allowRecreate bool, revealSecrets bool, preservePaths []string) (*openshift.Changeset, error) {
 	changeset, err := openshift.NewChangeset(remoteResourceList, localResourceList, upsertOnly, allowRecreate, preservePaths)
 	if err != nil {
 		return changeset, err
@@ -194,11 +193,7 @@ func compare(remoteResourceList *openshift.ResourceList, localResourceList *open
 
 	for _, change := range changeset.Update {
 		cli.PrintYellowf("~ %s to update\n", change.ItemName())
-		if format == "text" {
-			fmt.Print(change.Diff(revealSecrets))
-		} else {
-			fmt.Println(change.PrettyJSONPatches())
-		}
+		fmt.Print(change.Diff(revealSecrets))
 	}
 
 	fmt.Printf("\nSummary: %d in sync, ", len(changeset.Noop))

--- a/pkg/openshift/change.go
+++ b/pkg/openshift/change.go
@@ -1,11 +1,6 @@
 package openshift
 
 import (
-	"encoding/json"
-	"sort"
-
-	"github.com/opendevstack/tailor/pkg/cli"
-	"github.com/opendevstack/tailor/pkg/utils"
 	"github.com/pmezard/go-difflib/difflib"
 )
 
@@ -32,44 +27,20 @@ type Change struct {
 	Action       string
 	Kind         string
 	Name         string
-	Patches      []*jsonPatch
 	CurrentState string
 	DesiredState string
 }
 
-type jsonPatch struct {
-	Op    string      `json:"op"`
-	Path  string      `json:"path"`
-	Value interface{} `json:"value,omitempty"`
-}
-
-type jsonPatches []*jsonPatch
-
-func (jp jsonPatch) Pretty() string {
-	var b []byte
-	b, _ = json.MarshalIndent(jp, "", "  ")
-	return string(b)
-}
-
 // NewChange creates a new change for given template/platform item.
-func NewChange(templateItem *ResourceItem, platformItem *ResourceItem, comparison map[string]*jsonPatch) *Change {
+func NewChange(templateItem *ResourceItem, platformItem *ResourceItem) *Change {
 	c := &Change{
 		Kind:         templateItem.Kind,
 		Name:         templateItem.Name,
-		Patches:      []*jsonPatch{},
 		CurrentState: platformItem.YamlConfig(),
 		DesiredState: templateItem.YamlConfig(),
 	}
 
-	for path, patch := range comparison {
-		if patch.Op != "noop" {
-			cli.DebugMsg("add path", path)
-			patch.Path = path
-			c.addPatch(patch)
-		}
-	}
-
-	if len(c.Patches) > 0 {
+	if platformItem.YamlConfig() != templateItem.YamlConfig() {
 		c.Action = "Update"
 	} else {
 		c.Action = "Noop"
@@ -83,25 +54,9 @@ func (c *Change) ItemName() string {
 	return kindToShortMapping[c.Kind] + "/" + c.Name
 }
 
-// PrettyJSONPatches prints the JSON patches in pretty form (with indentation).
-func (c *Change) PrettyJSONPatches() string {
-	var b []byte
-	b, _ = json.MarshalIndent(c.Patches, "", "  ")
-	return string(b)
-}
-
-// JSONPatches prints the JSON patches in plain form.
-func (c *Change) JSONPatches() string {
-	var b []byte
-	b, _ = json.Marshal(c.Patches)
-	return string(b)
-}
-
 // Diff returns a unified diff text for the change.
 func (c *Change) Diff(revealSecrets bool) string {
-	if len(c.Patches) > 0 && c.patchesAreTailorInternalOnly() {
-		return "Only annotations used by Tailor internally differ. Updating the resource is recommended, but not required. Use --diff=json to see the exact changes.\n"
-	} else if c.isSecret() && !revealSecrets {
+	if c.isSecret() && !revealSecrets {
 		return "Secret drift is hidden. Use --reveal-secrets to see details.\n"
 	}
 	diff := difflib.UnifiedDiff{
@@ -115,23 +70,24 @@ func (c *Change) Diff(revealSecrets bool) string {
 	return text
 }
 
-func (c *Change) addPatch(patch *jsonPatch) {
-	c.Patches = append(c.Patches, patch)
-	sort.Slice(c.Patches, func(i, j int) bool {
-		return c.Patches[i].Path < c.Patches[j].Path
-	})
-}
-
-func (c *Change) patchesAreTailorInternalOnly() bool {
-	internalPaths := []string{tailorAppliedConfigAnnotationPath, tailorManagedAnnotationPath}
-	for _, p := range c.Patches {
-		if !utils.Includes(internalPaths, p.Path) {
-			return false
-		}
-	}
-	return true
-}
-
 func (c *Change) isSecret() bool {
 	return kindToShortMapping[c.Kind] == "secret"
+}
+
+func recreateChanges(templateItem, platformItem *ResourceItem) []*Change {
+	deleteChange := &Change{
+		Action:       "Delete",
+		Kind:         templateItem.Kind,
+		Name:         templateItem.Name,
+		CurrentState: platformItem.YamlConfig(),
+		DesiredState: "",
+	}
+	createChange := &Change{
+		Action:       "Create",
+		Kind:         templateItem.Kind,
+		Name:         templateItem.Name,
+		CurrentState: "",
+		DesiredState: templateItem.YamlConfig(),
+	}
+	return []*Change{deleteChange, createChange}
 }

--- a/pkg/openshift/item_test.go
+++ b/pkg/openshift/item_test.go
@@ -78,37 +78,6 @@ spec:
   - type: ConfigChange`)
 }
 
-func getChangedBuildConfig() []byte {
-	return []byte(
-		`apiVersion: v1
-kind: BuildConfig
-metadata:
-  annotations:
-    foo: bar
-  name: foo
-spec:
-  failedBuildsHistoryLimit: 8
-  nodeSelector: null
-  output:
-    to:
-      kind: ImageStreamTag
-      name: foo:experiment
-  postCommit: {}
-  resources: {}
-  runPolicy: Serial
-  source:
-    binary: {}
-    type: Binary
-  strategy:
-    dockerStrategy: {}
-    type: Docker
-  successfulBuildsHistoryLimit: 5
-  triggers:
-  - imageChange: {}
-    type: ImageChange
-  - type: ConfigChange`)
-}
-
 func getRoute(host []byte) []byte {
 	config := []byte(
 		`apiVersion: v1


### PR DESCRIPTION
This makes use of `oc apply` (client-side apply), as this is more solid
than the custom generation of patches used with `oc patch`.

Also, new resources are created with `oc apply` instead of `oc create`,
which has the advantage that Tailor does not fail when the desired state
defines a resource with a label that is not present in the current
state. Previously, Tailor did not "see" the resource in the current
state because it was not in scope, and therefore tried to create if
which failed. Now Tailor creates with `apply`, which ends up being a
merge, which is better.

The change removes the custom Tailor annotations, it just makes use of
the `kubectl.kubernetes.io/last-applied-configuration` annotation.

This annotation is used during client-side apply, which is also known to
cause problems, which is why Kubernetes has introduced a server-side
apply, which is based on field ownership. Long-term, this is something
that Tailor could use as well, but right now, Tailor targets OpenShift
v3, which uses a Kubernetes version which only supports client-side
apply, and therefore using the annotation is a good fit.

If there are any issues with unexpected drift or problems when
reconciling, please consult
https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/.