### PR TITLE
Avoid --force flag when run against local cluster

### DIFF
--- a/internal/test/e2e/full_test.go
+++ b/internal/test/e2e/full_test.go
@@ -40,7 +40,7 @@ objects:
 	}
 
 	// Status -> expected to have one created resource
-	cmd := exec.Command(tailorBinary, []string{"diff", "--force"}...)
+	cmd := exec.Command(tailorBinary, []string{"diff"}...)
 	out, err := cmd.CombinedOutput()
 	if err == nil {
 		t.Fatalf("Status command should have exited with 3")
@@ -83,7 +83,7 @@ objects:
 	}
 
 	// Status -> expected to have drift (updated resource)
-	cmd = exec.Command(tailorBinary, []string{"diff", "--force"}...)
+	cmd = exec.Command(tailorBinary, []string{"diff"}...)
 	out, err = cmd.CombinedOutput()
 	if err == nil {
 		t.Fatalf("Status command should have exited with 3")
@@ -114,7 +114,7 @@ objects:
 	t.Log("Patched content of ConfigMap")
 
 	// Status -> expected to have drift (updated resource)
-	cmd = exec.Command(tailorBinary, []string{"diff", "--force"}...)
+	cmd = exec.Command(tailorBinary, []string{"diff"}...)
 	out, err = cmd.CombinedOutput()
 	if err == nil {
 		t.Fatalf("Status command should have exited with 3")
@@ -139,7 +139,7 @@ objects:
 	os.Remove("cm-template.yml")
 
 	// Status -> expected to have drift (deleted resource)
-	cmd = exec.Command(tailorBinary, []string{"diff", "--force"}...)
+	cmd = exec.Command(tailorBinary, []string{"diff"}...)
 	out, err = cmd.CombinedOutput()
 	if err == nil {
 		t.Fatalf("Status command should have exited with 3")
@@ -164,7 +164,7 @@ objects:
 
 func runApply(t *testing.T, tailorBinary string) {
 	t.Log("Updating test project")
-	cmd := exec.Command(tailorBinary, []string{"apply", "--non-interactive", "--force"}...)
+	cmd := exec.Command(tailorBinary, []string{"apply", "--non-interactive"}...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Could not update test project: %s", out)
@@ -174,7 +174,7 @@ func runApply(t *testing.T, tailorBinary string) {
 
 func diffWithNoExpectedDrift(t *testing.T, tailorBinary string) {
 	t.Log("Calculating diff ...")
-	cmd := exec.Command(tailorBinary, []string{"diff", "--force"}...)
+	cmd := exec.Command(tailorBinary, []string{"diff"}...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Could not get status in test project: %s", out)
@@ -195,7 +195,7 @@ func diffWithNoExpectedDrift(t *testing.T, tailorBinary string) {
 }
 
 func runExport(t *testing.T, tailorBinary string) {
-	cmd := exec.Command(tailorBinary, []string{"export", "--force"}...)
+	cmd := exec.Command(tailorBinary, []string{"export"}...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Could not export resources in test project: %s", out)

--- a/internal/test/e2e/partial_test.go
+++ b/internal/test/e2e/partial_test.go
@@ -108,7 +108,7 @@ objects:
 	}
 
 	// Status for app=foo -> expected to have drift (updated resource)
-	cmd := exec.Command(tailorBinary, []string{"diff", "--force", "-l", "app=foo"}...)
+	cmd := exec.Command(tailorBinary, []string{"diff", "-l", "app=foo"}...)
 	out, err := cmd.CombinedOutput()
 	if err == nil {
 		t.Fatalf("Status command should have exited with 3")
@@ -131,7 +131,7 @@ objects:
 }
 
 func partialStatusWithNoExpectedDrift(t *testing.T, tailorBinary string, label string) {
-	cmd := exec.Command(tailorBinary, []string{"diff", "--force", "-l", label}...)
+	cmd := exec.Command(tailorBinary, []string{"diff", "-l", label}...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Could not get status for %s in test project", label)

--- a/internal/test/fixtures/version/client-3_11-and-server-unknown.txt
+++ b/internal/test/fixtures/version/client-3_11-and-server-unknown.txt
@@ -1,4 +1,4 @@
-oc v3.9.0+191fece
-kubernetes v1.9.1+a0ce1bc657
+oc v3.11.0+0cbc58b
+kubernetes v1.11.0+d4cacc0
 features: Basic-Auth
 

--- a/pkg/cli/oc_version.go
+++ b/pkg/cli/oc_version.go
@@ -10,13 +10,13 @@ type openshiftVersion struct {
 	server string
 }
 
-// Matches is true when client and server version are equal.
-func (ov openshiftVersion) Matches() bool {
-	return ov.client == ov.server
+// ExactMatch is true when client and server version are known and equal.
+func (ov openshiftVersion) ExactMatch() bool {
+	return !ov.Incomplete() && ov.client == ov.server
 }
 
-// Unknown returns true if at least one version could not be detected properly.
-func (ov openshiftVersion) Unknown() bool {
+// Incomplete returns true if at least one version could not be detected properly.
+func (ov openshiftVersion) Incomplete() bool {
 	return ov.client == "?" || ov.server == "?"
 }
 
@@ -57,7 +57,7 @@ func ocVersion(ocClient OcClientVersioner) openshiftVersion {
 		ov.server = ocServerVersion
 	}
 
-	if ov.Unknown() {
+	if ov.Incomplete() {
 		VerboseMsg("Client and server version could not be detected properly, got:", output)
 		return ov
 	}

--- a/pkg/cli/oc_version_test.go
+++ b/pkg/cli/oc_version_test.go
@@ -34,7 +34,7 @@ func TestOcVersion(t *testing.T) {
 		},
 		"client=3.11 and server=?": {
 			fixture:        "client-3_11-and-server-unknown.txt",
-			expectedClient: "v3.9",
+			expectedClient: "v3.11",
 			expectedServer: "?",
 		},
 	}

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -457,14 +457,19 @@ func (o *GlobalOptions) check(clusterRequired bool) error {
 			return errors.New("You need to login with 'oc login' first")
 		}
 		c := NewOcClient("")
-		if v := ocVersion(c); !v.Matches() {
-			errorMsg := fmt.Sprintf("Version mismatch between client (%s) and server (%s) detected. "+
-				"This can lead to incorrect behaviour. "+
-				"Update your oc binary or point to an alternative binary with --oc-binary.", v.client, v.server)
-			if !o.Force {
-				return fmt.Errorf("%s\n\nRefusing to continue without --force", errorMsg)
+		if v := ocVersion(c); !v.ExactMatch() {
+			if v.Incomplete() {
+				VerboseMsg(fmt.Sprintf("Version information is incomplete: client (%s) and server (%s) detected. "+
+					"This is likely due to a local cluster setup. "+
+					"If not, this could lead to incorrect behaviour.", v.client, v.server))
+			} else {
+				errorMsg := fmt.Sprintf("Version mismatch between client (%s) and server (%s) detected. "+
+					"This can lead to incorrect behaviour. "+
+					"Update your oc binary or point to an alternative binary with --oc-binary.", v.client, v.server)
+				if !o.Force {
+					return fmt.Errorf("%s\n\nRefusing to continue without --force", errorMsg)
+				}
 			}
-			VerboseMsg(errorMsg)
 		}
 	}
 	return nil


### PR DESCRIPTION
If only the client version can be detected, Tailor will continue without
--force now (as for some reason "oc cluster up" does not report the server
version).

Closes #127.