### PR TITLE
Allow users to selectively apply changes

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -102,27 +102,36 @@ func execCmd(executable string, args []string) *exec.Cmd {
 	return exec.Command(executable, args...)
 }
 
-// AskForConfirmation asks the user for confirmation. A user must type in "yes" or "no" and
-// then press enter. It has fuzzy matching, so "y", "Y", "yes", "YES", and "Yes" all count as
-// confirmations. If the input is not recognized, it will ask again. The function does not return
+// AskForAction asks the user the given question. A user must type in one of the presented options and
+// then press enter.If the input is not recognized, it will ask again. The function does not return
 // until it gets a valid response from the user.
-func AskForConfirmation(s string) bool {
-	reader := bufio.NewReader(os.Stdin)
+// Options are of form "y=yes". The matching is fuzzy, which means allowed values are
+// "y", "Y", "yes", "YES", "Yes" and so on. The returned value is always the "key" ("y" in this case),
+// regardless if the input was "y" or "yes" etc.
+func AskForAction(question string, options []string, stdin io.Reader) string {
+	reader := bufio.NewReader(stdin)
+
+	validAnswers := map[string]string{}
+	for _, v := range options {
+		p := strings.Split(v, "=")
+		validAnswers[p[0]] = p[0]
+		validAnswers[p[1]] = p[0]
+	}
 
 	for {
-		fmt.Printf("%s [y/n]: ", s)
+		fmt.Printf("%s [%s]: ", question, strings.Join(options, ", "))
 
-		response, err := reader.ReadString('\n')
+		answer, err := reader.ReadString('\n')
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		response = strings.ToLower(strings.TrimSpace(response))
+		answer = strings.ToLower(strings.TrimSpace(answer))
 
-		if response == "y" || response == "yes" {
-			return true
-		} else if response == "n" || response == "no" {
-			return false
+		if v, ok := validAnswers[answer]; !ok {
+			fmt.Printf("'%s' is not a valid option. Please try again.\n", answer)
+		} else {
+			return v
 		}
 	}
 }

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestAskForAction(t *testing.T) {
+	tests := map[string]struct {
+		input          string
+		options        []string
+		expectedAnswer string
+	}{
+		"input of key of one option": {
+			input:          "y\n",
+			options:        []string{"y=yes", "n=no"},
+			expectedAnswer: "y",
+		},
+		"input of value of one option": {
+			input:          "yes\n",
+			options:        []string{"y=yes", "n=no"},
+			expectedAnswer: "y",
+		},
+		"input of key with uppercase character": {
+			input:          "Y\n",
+			options:        []string{"y=yes", "n=no"},
+			expectedAnswer: "y",
+		},
+		"input of value with uppercase character": {
+			input:          "Yes\n",
+			options:        []string{"y=yes", "n=no"},
+			expectedAnswer: "y",
+		},
+		"input of invalid answer at first": {
+			input:          "m\nn\n",
+			options:        []string{"y=yes", "n=no"},
+			expectedAnswer: "n",
+		},
+		"empty input at first": {
+			input:          "\ny\n",
+			options:        []string{"y=yes", "n=no"},
+			expectedAnswer: "y",
+		},
+		"input with surrounding space": {
+			input:          " no \n",
+			options:        []string{"y=yes", "n=no"},
+			expectedAnswer: "n",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var stdin bytes.Buffer
+			stdin.Write([]byte(tc.input))
+			a := AskForAction("What?", tc.options, &stdin)
+			if a != tc.expectedAnswer {
+				t.Fatalf("Want: '%s', got: '%s'", tc.expectedAnswer, a)
+			}
+		})
+	}
+}

--- a/pkg/cli/oc_client.go
+++ b/pkg/cli/oc_client.go
@@ -14,6 +14,12 @@ type ClientProcessorExporter interface {
 	OcClientExporter
 }
 
+// ClientModifier allows to delete and create/update resources.
+type ClientModifier interface {
+	OcClientApplier
+	OcClientDeleter
+}
+
 // OcClientProcessor is a stop-gap solution only ... should have a better API.
 type OcClientProcessor interface {
 	Process(args []string) ([]byte, []byte, error)
@@ -29,7 +35,7 @@ type OcClientDeleter interface {
 	Delete(kind string, name string) ([]byte, error)
 }
 
-// OcClientApplier allows to create a resource.
+// OcClientApplier allows to create/update a resource.
 type OcClientApplier interface {
 	Apply(config string, selector string) ([]byte, error)
 }

--- a/pkg/commands/diff.go
+++ b/pkg/commands/diff.go
@@ -144,18 +144,15 @@ func compare(w io.Writer, remoteResourceList *openshift.ResourceList, localResou
 	}
 
 	for _, change := range changeset.Delete {
-		cli.FprintRedf(w, "- %s to delete\n", change.ItemName())
-		fmt.Fprint(w, change.Diff(revealSecrets))
+		printDeleteChange(w, change, revealSecrets)
 	}
 
 	for _, change := range changeset.Create {
-		cli.FprintGreenf(w, "+ %s to create\n", change.ItemName())
-		fmt.Fprint(w, change.Diff(revealSecrets))
+		printCreateChange(w, change, revealSecrets)
 	}
 
 	for _, change := range changeset.Update {
-		cli.FprintYellowf(w, "~ %s to update\n", change.ItemName())
-		fmt.Fprint(w, change.Diff(revealSecrets))
+		printUpdateChange(w, change, revealSecrets)
 	}
 
 	fmt.Fprintf(w, "\nSummary: %d in sync, ", len(changeset.Noop))
@@ -166,6 +163,21 @@ func compare(w io.Writer, remoteResourceList *openshift.ResourceList, localResou
 	cli.FprintRedf(w, "%d to delete\n\n", len(changeset.Delete))
 
 	return changeset, nil
+}
+
+func printDeleteChange(w io.Writer, change *openshift.Change, revealSecrets bool) {
+	cli.FprintRedf(w, "- %s to delete\n", change.ItemName())
+	fmt.Fprint(w, change.Diff(revealSecrets))
+}
+
+func printCreateChange(w io.Writer, change *openshift.Change, revealSecrets bool) {
+	cli.FprintGreenf(w, "+ %s to create\n", change.ItemName())
+	fmt.Fprint(w, change.Diff(revealSecrets))
+}
+
+func printUpdateChange(w io.Writer, change *openshift.Change, revealSecrets bool) {
+	cli.FprintYellowf(w, "~ %s to update\n", change.ItemName())
+	fmt.Fprint(w, change.Diff(revealSecrets))
 }
 
 func assembleTemplateBasedResourceList(filter *openshift.ResourceFilter, compareOptions *cli.CompareOptions, ocClient cli.OcClientProcessor) (*openshift.ResourceList, error) {

--- a/pkg/openshift/changeset.go
+++ b/pkg/openshift/changeset.go
@@ -278,10 +278,17 @@ func calculateChanges(templateItem *ResourceItem, platformItem *ResourceItem, pr
 	return []*Change{c}, nil
 }
 
+// Blank is true when there is no change across Create, Update, Delete.
 func (c *Changeset) Blank() bool {
 	return len(c.Create) == 0 && len(c.Update) == 0 && len(c.Delete) == 0
 }
 
+// ExactlyOne is true when there is just a single change across Create, Update, Delete.
+func (c *Changeset) ExactlyOne() bool {
+	return len(c.Create)+len(c.Update)+len(c.Delete) == 1
+}
+
+// Add adds given changes to the changeset.
 func (c *Changeset) Add(changes ...*Change) {
 	for _, change := range changes {
 		switch change.Action {


### PR DESCRIPTION
Instead of applying all changes in one go, present one change at a time
and allow the user to apply or skip the change.

Closes #159.