### PR TITLE
Allow --exclude to be repeated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: go
 go:
   - "1.12.x"
 before_install:
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.25.0
   - go get golang.org/x/tools/cmd/goimports
   - wget https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
   - tar -xzvf openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ services:
   - docker
 language: go
 go:
-  - "1.12.x"
+  - "1.14.x"
 before_install:
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.25.0
   - go get golang.org/x/tools/cmd/goimports

--- a/cmd/tailor/main.go
+++ b/cmd/tailor/main.go
@@ -51,8 +51,8 @@ var (
 	).Short('l').String()
 	excludeFlag = app.Flag(
 		"exclude",
-		"Exclude kinds, names and labels (comma separated)",
-	).Short('e').String()
+		"Exclude kinds, names and labels (repeatable or comma-separated)",
+	).Short('e').Strings()
 	templateDirFlag = app.Flag(
 		"template-dir",
 		"Path to local templates",

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -34,7 +34,7 @@ type CompareOptions struct {
 	*GlobalOptions
 	*NamespaceOptions
 	Selector                string
-	Exclude                 string
+	Excludes                []string
 	TemplateDir             string
 	ParamDir                string
 	PrivateKey              string
@@ -57,7 +57,7 @@ type ExportOptions struct {
 	*GlobalOptions
 	*NamespaceOptions
 	Selector               string
-	Exclude                string
+	Excludes               []string
 	TemplateDir            string
 	ParamDir               string
 	WithAnnotations        bool
@@ -145,7 +145,7 @@ func NewCompareOptions(
 	globalOptions *GlobalOptions,
 	namespaceFlag string,
 	selectorFlag string,
-	excludeFlag string,
+	excludeFlag []string,
 	templateDirFlag string,
 	paramDirFlag string,
 	publicKeyDirFlag string,
@@ -170,7 +170,7 @@ func NewCompareOptions(
 
 	fileFlags, err := getFileFlags(filename, verbose)
 	if err != nil {
-		return o, fmt.Errorf("Could not read %s: %s", filename, err)
+		return o, fmt.Errorf("Could not read '%s': %s", filename, err)
 	}
 
 	if len(namespaceFlag) > 0 {
@@ -185,10 +185,13 @@ func NewCompareOptions(
 		o.Selector = val
 	}
 
+	o.Excludes = []string{}
 	if len(excludeFlag) > 0 {
-		o.Exclude = excludeFlag
+		for _, val := range excludeFlag {
+			o.Excludes = append(o.Excludes, strings.Split(val, ",")...)
+		}
 	} else if val, ok := fileFlags["exclude"]; ok {
-		o.Exclude = val
+		o.Excludes = strings.Split(val, ",")
 	}
 
 	o.TemplateDir = "."
@@ -319,7 +322,7 @@ func NewExportOptions(
 	globalOptions *GlobalOptions,
 	namespaceFlag string,
 	selectorFlag string,
-	excludeFlag string,
+	excludeFlag []string,
 	templateDirFlag string,
 	paramDirFlag string,
 	withAnnotationsFlag bool,
@@ -349,10 +352,13 @@ func NewExportOptions(
 		o.Selector = val
 	}
 
+	o.Excludes = []string{}
 	if len(excludeFlag) > 0 {
-		o.Exclude = excludeFlag
+		for _, val := range excludeFlag {
+			o.Excludes = append(o.Excludes, strings.Split(val, ",")...)
+		}
 	} else if val, ok := fileFlags["exclude"]; ok {
-		o.Exclude = val
+		o.Excludes = strings.Split(val, ",")
 	}
 
 	o.TemplateDir = "."
@@ -517,14 +523,14 @@ func (o *CompareOptions) check() error {
 	if o.TemplateDir != "." {
 		td := o.TemplateDir
 		if _, err := os.Stat(td); os.IsNotExist(err) {
-			return fmt.Errorf("Template directory %s does not exist", td)
+			return fmt.Errorf("Template directory '%s' does not exist", td)
 		}
 	}
 	// Check if param dir exists
 	if o.ParamDir != "." {
 		pd := o.ParamDir
 		if _, err := os.Stat(pd); os.IsNotExist(err) {
-			return fmt.Errorf("Param directory %s does not exist", pd)
+			return fmt.Errorf("Param directory '%s' does not exist", pd)
 		}
 	}
 

--- a/pkg/cli/options_test.go
+++ b/pkg/cli/options_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/opendevstack/tailor/internal/test/helper"
 	"github.com/opendevstack/tailor/pkg/utils"
 )
@@ -52,6 +53,122 @@ func TestResolvedFile(t *testing.T) {
 			actual := o.resolvedFile(tc.namespaceFlag)
 			if actual != tc.expected {
 				t.Fatalf("Expected file: '%s', got: '%s'", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestNewCompareOptionsExcludes(t *testing.T) {
+	tests := map[string]struct {
+		excludeFlag  []string
+		wantExcludes []string
+	}{
+		"none": {
+			excludeFlag:  []string{},
+			wantExcludes: []string{},
+		},
+		"passed once": {
+			excludeFlag:  []string{"bc"},
+			wantExcludes: []string{"bc"},
+		},
+		"passed once comma-separated": {
+			excludeFlag:  []string{"bc,is"},
+			wantExcludes: []string{"bc", "is"},
+		},
+		"passed multiple times": {
+			excludeFlag:  []string{"bc", "is"},
+			wantExcludes: []string{"bc", "is"},
+		},
+		"passed multiple times and comma-separated": {
+			excludeFlag:  []string{"bc,is", "route"},
+			wantExcludes: []string{"bc", "is", "route"},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			o, err := NewGlobalOptions(false, "Tailorfile", false, false, false, "oc", false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := NewCompareOptions(
+				o,
+				"",
+				"",
+				tc.excludeFlag,
+				".",
+				".",
+				"",
+				"",
+				"",
+				"",
+				[]string{},
+				[]string{},
+				[]string{},
+				false,
+				false,
+				false,
+				false,
+				false,
+				false,
+				"")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tc.wantExcludes, got.Excludes); diff != "" {
+				t.Errorf("Compare options mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNewExportOptionsExcludes(t *testing.T) {
+	tests := map[string]struct {
+		excludeFlag  []string
+		wantExcludes []string
+	}{
+		"none": {
+			excludeFlag:  []string{},
+			wantExcludes: []string{},
+		},
+		"passed once": {
+			excludeFlag:  []string{"bc"},
+			wantExcludes: []string{"bc"},
+		},
+		"passed once comma-separated": {
+			excludeFlag:  []string{"bc,is"},
+			wantExcludes: []string{"bc", "is"},
+		},
+		"passed multiple times": {
+			excludeFlag:  []string{"bc", "is"},
+			wantExcludes: []string{"bc", "is"},
+		},
+		"passed multiple times and comma-separated": {
+			excludeFlag:  []string{"bc,is", "route"},
+			wantExcludes: []string{"bc", "is", "route"},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			o, err := NewGlobalOptions(false, "Tailorfile", false, false, false, "oc", false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := NewExportOptions(
+				o,
+				"",
+				"",
+				tc.excludeFlag,
+				".",
+				".",
+				false,
+				false,
+				[]string{},
+				"")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tc.wantExcludes, got.Excludes); diff != "" {
+				t.Errorf("Export options mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/commands/diff.go
+++ b/pkg/commands/diff.go
@@ -52,7 +52,7 @@ func calculateChangeset(w io.Writer, compareOptions *cli.CompareOptions, ocClien
 
 	resource := compareOptions.Resource
 
-	filter, err := openshift.NewResourceFilter(resource, compareOptions.Selector, compareOptions.Exclude)
+	filter, err := openshift.NewResourceFilter(resource, compareOptions.Selector, compareOptions.Excludes)
 	if err != nil {
 		return updateRequired, &openshift.Changeset{}, err
 	}

--- a/pkg/commands/export.go
+++ b/pkg/commands/export.go
@@ -9,7 +9,7 @@ import (
 
 // Export prints an export of targeted resources to STDOUT.
 func Export(exportOptions *cli.ExportOptions) error {
-	filter, err := openshift.NewResourceFilter(exportOptions.Resource, exportOptions.Selector, exportOptions.Exclude)
+	filter, err := openshift.NewResourceFilter(exportOptions.Resource, exportOptions.Selector, exportOptions.Excludes)
 	if err != nil {
 		return err
 	}

--- a/pkg/openshift/changeset_test.go
+++ b/pkg/openshift/changeset_test.go
@@ -33,7 +33,7 @@ func TestNewChangesetCreationOfResources(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			filter, err := NewResourceFilter("", "", "")
+			filter, err := NewResourceFilter("", "", []string{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -73,7 +73,7 @@ func TestNewChangesetCreationOfResources(t *testing.T) {
 			want := string(helper.ReadGoldenFile(t, "desired-state/"+tc.expectedGolden))
 			got := createChange.DesiredState
 			if diff := cmp.Diff(want, got); diff != "" {
-				t.Errorf("Desired state mismatch (-want +got):\n%s", diff)
+				t.Fatalf("Desired state mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/openshift/export_test.go
+++ b/pkg/openshift/export_test.go
@@ -16,8 +16,8 @@ func (c *mockOcExportClient) Export(target string, label string) ([]byte, error)
 	return helper.ReadFixtureFile(c.t, "export/"+c.fixture), nil
 }
 
-func newResourceFilterOrFatal(t *testing.T, kindArg string, selectorFlag string, excludeFlag string) *ResourceFilter {
-	filter, err := NewResourceFilter(kindArg, selectorFlag, excludeFlag)
+func newResourceFilterOrFatal(t *testing.T, kindArg string, selectorFlag string, excludes []string) *ResourceFilter {
+	filter, err := NewResourceFilter(kindArg, selectorFlag, excludes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func TestExportAsTemplateFile(t *testing.T) {
 		"Without all annotations": {
 			fixture:                "is.yml",
 			goldenTemplate:         "is.yml",
-			filter:                 newResourceFilterOrFatal(t, "is", "", ""),
+			filter:                 newResourceFilterOrFatal(t, "is", "", []string{}),
 			withAnnotations:        false,
 			trimAnnotations:        []string{},
 			namespace:              "foo",
@@ -46,7 +46,7 @@ func TestExportAsTemplateFile(t *testing.T) {
 		"With all annotations": {
 			fixture:                "is.yml",
 			goldenTemplate:         "is-annotation.yml",
-			filter:                 newResourceFilterOrFatal(t, "is", "", ""),
+			filter:                 newResourceFilterOrFatal(t, "is", "", []string{}),
 			withAnnotations:        true,
 			trimAnnotations:        []string{},
 			namespace:              "foo",
@@ -55,7 +55,7 @@ func TestExportAsTemplateFile(t *testing.T) {
 		"With trimmed annotation": {
 			fixture:                "is.yml",
 			goldenTemplate:         "is-trimmed-annotation.yml",
-			filter:                 newResourceFilterOrFatal(t, "is", "", ""),
+			filter:                 newResourceFilterOrFatal(t, "is", "", []string{}),
 			withAnnotations:        false,
 			trimAnnotations:        []string{"description"},
 			namespace:              "foo",
@@ -64,7 +64,7 @@ func TestExportAsTemplateFile(t *testing.T) {
 		"With trimmed annotation prefix": {
 			fixture:                "is.yml",
 			goldenTemplate:         "is-trimmed-annotation-prefix.yml",
-			filter:                 newResourceFilterOrFatal(t, "is", "", ""),
+			filter:                 newResourceFilterOrFatal(t, "is", "", []string{}),
 			withAnnotations:        false,
 			trimAnnotations:        []string{"openshift.io/"},
 			namespace:              "foo",
@@ -73,7 +73,7 @@ func TestExportAsTemplateFile(t *testing.T) {
 		"With TAILOR_NAMESPACE": {
 			fixture:                "bc.yml",
 			goldenTemplate:         "bc.yml",
-			filter:                 newResourceFilterOrFatal(t, "bc", "", ""),
+			filter:                 newResourceFilterOrFatal(t, "bc", "", []string{}),
 			withAnnotations:        false,
 			trimAnnotations:        []string{},
 			namespace:              "foo-dev",
@@ -82,7 +82,7 @@ func TestExportAsTemplateFile(t *testing.T) {
 		"Works with generateName": {
 			fixture:                "rolebinding-generate-name.yml",
 			goldenTemplate:         "rolebinding-generate-name.yml",
-			filter:                 newResourceFilterOrFatal(t, "rolebinding", "", ""),
+			filter:                 newResourceFilterOrFatal(t, "rolebinding", "", []string{}),
 			withAnnotations:        false,
 			trimAnnotations:        []string{},
 			namespace:              "foo",
@@ -91,7 +91,7 @@ func TestExportAsTemplateFile(t *testing.T) {
 		"Respects filter": {
 			fixture:                "is.yml",
 			goldenTemplate:         "empty.yml",
-			filter:                 newResourceFilterOrFatal(t, "bc", "", ""),
+			filter:                 newResourceFilterOrFatal(t, "bc", "", []string{}),
 			withAnnotations:        false,
 			namespace:              "foo",
 			withHardcodedNamespace: true,

--- a/pkg/openshift/filter_test.go
+++ b/pkg/openshift/filter_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNewResourceFilter(t *testing.T) {
-	actual, err := NewResourceFilter("pvc", "", "")
+	actual, err := NewResourceFilter("pvc", "", []string{})
 	expected := &ResourceFilter{
 		Kinds: []string{"PersistentVolumeClaim"},
 		Name:  "",
@@ -18,7 +18,7 @@ func TestNewResourceFilter(t *testing.T) {
 		t.Errorf("Kinds incorrect, got: %v, want: %v.", actual, expected)
 	}
 
-	actual, err = NewResourceFilter("pvc,dc", "", "")
+	actual, err = NewResourceFilter("pvc,dc", "", []string{})
 	expected = &ResourceFilter{
 		Kinds: []string{"DeploymentConfig", "PersistentVolumeClaim"},
 		Name:  "",
@@ -28,7 +28,7 @@ func TestNewResourceFilter(t *testing.T) {
 		t.Errorf("Kinds incorrect, got: %v, want: %v.", actual, expected)
 	}
 
-	actual, err = NewResourceFilter("pvc,persistentvolumeclaim,PersistentVolumeClaim", "", "")
+	actual, err = NewResourceFilter("pvc,persistentvolumeclaim,PersistentVolumeClaim", "", []string{})
 	expected = &ResourceFilter{
 		Kinds: []string{"PersistentVolumeClaim"},
 		Name:  "",
@@ -38,12 +38,12 @@ func TestNewResourceFilter(t *testing.T) {
 		t.Errorf("Kinds incorrect, got: %v, want: %v.", actual, expected)
 	}
 
-	_, err = NewResourceFilter("pvb", "", "")
+	_, err = NewResourceFilter("pvb", "", []string{})
 	if err == nil {
 		t.Errorf("Expected to detect unknown kind pvb.")
 	}
 
-	actual, err = NewResourceFilter("dc/foo", "", "")
+	actual, err = NewResourceFilter("dc/foo", "", []string{})
 	expected = &ResourceFilter{
 		Kinds: []string{},
 		Name:  "DeploymentConfig/foo",
@@ -53,7 +53,7 @@ func TestNewResourceFilter(t *testing.T) {
 		t.Errorf("Kinds incorrect, got: %v, want: %v.", actual, expected)
 	}
 
-	actual, err = NewResourceFilter("pvc", "name=foo", "")
+	actual, err = NewResourceFilter("pvc", "name=foo", []string{})
 	expected = &ResourceFilter{
 		Kinds: []string{"PersistentVolumeClaim"},
 		Name:  "",
@@ -63,7 +63,7 @@ func TestNewResourceFilter(t *testing.T) {
 		t.Errorf("Kinds incorrect, got: %v, want: %v.", actual, expected)
 	}
 
-	actual, err = NewResourceFilter("pvc,dc", "name=foo", "")
+	actual, err = NewResourceFilter("pvc,dc", "name=foo", []string{})
 	expected = &ResourceFilter{
 		Kinds: []string{"DeploymentConfig", "PersistentVolumeClaim"},
 		Name:  "",
@@ -84,84 +84,84 @@ metadata:
 	tests := map[string]struct {
 		kindArg      string
 		selectorFlag string
-		excludeFlag  string
+		excludes     []string
 		config       []byte
 		expected     bool
 	}{
 		"item is included when no constraints are specified": {
 			kindArg:      "",
 			selectorFlag: "",
-			excludeFlag:  "",
+			excludes:     []string{},
 			config:       bc,
 			expected:     true,
 		},
 		"item is included when kind is specified": {
 			kindArg:      "bc",
 			selectorFlag: "",
-			excludeFlag:  "",
+			excludes:     []string{},
 			config:       bc,
 			expected:     true,
 		},
 		"item is included when name is specified": {
 			kindArg:      "bc/foo",
 			selectorFlag: "",
-			excludeFlag:  "",
+			excludes:     []string{},
 			config:       bc,
 			expected:     true,
 		},
 		"item is included when label is specified": {
 			kindArg:      "",
 			selectorFlag: "app=foo",
-			excludeFlag:  "",
+			excludes:     []string{},
 			config:       bc,
 			expected:     true,
 		},
 		"item is excluded when only some other kind is specified": {
 			kindArg:      "is",
 			selectorFlag: "",
-			excludeFlag:  "",
+			excludes:     []string{},
 			config:       bc,
 			expected:     false,
 		},
 		"item is excluded when kind is excluded": {
 			kindArg:      "",
 			selectorFlag: "",
-			excludeFlag:  "bc",
+			excludes:     []string{"bc"},
 			config:       bc,
 			expected:     false,
 		},
 		"item is excluded when name is excluded": {
 			kindArg:      "",
 			selectorFlag: "",
-			excludeFlag:  "bc/foo",
+			excludes:     []string{"bc/foo"},
 			config:       bc,
 			expected:     false,
 		},
 		"item is excluded when label is excluded": {
 			kindArg:      "",
 			selectorFlag: "",
-			excludeFlag:  "app=foo",
+			excludes:     []string{"app=foo"},
 			config:       bc,
 			expected:     false,
 		},
 		"item is excluded when multiple excludes are given that match": {
 			kindArg:      "",
 			selectorFlag: "",
-			excludeFlag:  "app=foo,bc/foo",
+			excludes:     []string{"app=foo", "bc/foo"},
 			config:       bc,
 			expected:     false,
 		},
 		"item is excluded when multiple excludes are given that partially match": {
 			kindArg:      "",
 			selectorFlag: "",
-			excludeFlag:  "app=foobar,bc/foo",
+			excludes:     []string{"app=foobar", "bc/foo"},
 			config:       bc,
 			expected:     false,
 		},
 		"item is not excluded when multiple excludes are given that do not match": {
 			kindArg:      "",
 			selectorFlag: "",
-			excludeFlag:  "app=foobar,dc/foo",
+			excludes:     []string{"app=foobar", "dc/foo"},
 			config:       bc,
 			expected:     true,
 		},
@@ -173,7 +173,7 @@ metadata:
 			if err != nil {
 				t.Fatal(err)
 			}
-			filter, err := NewResourceFilter(tc.kindArg, tc.selectorFlag, tc.excludeFlag)
+			filter, err := NewResourceFilter(tc.kindArg, tc.selectorFlag, tc.excludes)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/openshift/template.go
+++ b/pkg/openshift/template.go
@@ -86,9 +86,9 @@ func templateContainsTailorNamespaceParam(filename string) (bool, error) {
 		return false, err
 	}
 	var m map[string]interface{}
-	switch f.(type) {
+	switch f := f.(type) {
 	case map[string]interface{}:
-		m = f.(map[string]interface{})
+		m = f
 	case []interface{}:
 		return false, errors.New("Not a valid template. Did you forget to add the template header?\n\napiVersion: v1\nkind: Template\nobjects: [...]")
 	default:


### PR DESCRIPTION
This bring the flag in line with others such as `--preserve` or `--param-file`.

The option parsing / reading cries for a refactor, but I don't want to go there for this PR.