### PR TITLE
Replace only whole words with TAILOR_NAMESPACE

### DIFF
--- a/internal/test/fixtures/export/bc.yml
+++ b/internal/test/fixtures/export/bc.yml
@@ -4,6 +4,10 @@ items:
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
+    labels:
+      app: foo-deviations
+      component: foo-dev-monitoring
+      dotted: some.foo-dev.thing
     name: bar
   spec:
     nodeSelector: null
@@ -17,7 +21,7 @@ items:
     source:
       git:
         ref: master
-        uri: https://github.com/foo/bar.git
+        uri: https://github.com/foo-dev/bar.git
       type: Git
     strategy:
       dockerStrategy:

--- a/internal/test/golden/export/bc.yml
+++ b/internal/test/golden/export/bc.yml
@@ -4,6 +4,10 @@ objects:
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
+    labels:
+      app: foo-deviations
+      component: foo-dev-monitoring
+      dotted: some.${TAILOR_NAMESPACE}.thing
     name: bar
   spec:
     nodeSelector: null
@@ -17,7 +21,7 @@ objects:
     source:
       git:
         ref: master
-        uri: https://github.com/foo/bar.git
+        uri: https://github.com/${TAILOR_NAMESPACE}/bar.git
       type: Git
     strategy:
       dockerStrategy:


### PR DESCRIPTION
As https://github.com/opendevstack/ods-provisioning-app/issues/521 has
shown, the namespace replacement is too broad.

Right now, I mainly see the following use-cases:

* Replacement in URLs (e.g. `BuildConfig` `.spec.source.git.uri`)
* Replacement in image references (e.g. `DeploymentConfig`
`.spec.template.spec.containers[*].image`)
* Replacement of full field value (e.g. `BuildConfig` `.spec.strategy.dockerStrategy.from.namespace`)
* Internal routes such as `http://service-foo.namespace-bar.svc:8080`

All those use cases are satisfied by matching only whole words.

On the other hand, it is unlikely people want to replace partial words -
and the shorter the namespace, the more likely that "error" occurs.

The test which is using the fixtures/golden files is at https://github.com/opendevstack/tailor/blob/42e178f9d8111ff263e67006223bb803f60451ca/pkg/openshift/export_test.go#L73-L81