### PR TITLE
Fix job handling

### DIFF
--- a/pkg/openshift/filter.go
+++ b/pkg/openshift/filter.go
@@ -22,6 +22,8 @@ var availableKinds = []string{
 	"secret",
 	"rolebinding",
 	"serviceaccount",
+	"cronjob",
+	"job",
 }
 
 type ResourceFilter struct {

--- a/pkg/openshift/filter.go
+++ b/pkg/openshift/filter.go
@@ -24,6 +24,8 @@ var availableKinds = []string{
 	"serviceaccount",
 	"cronjob",
 	"job",
+	"limitrange",
+	"quota",
 }
 
 type ResourceFilter struct {

--- a/pkg/openshift/item.go
+++ b/pkg/openshift/item.go
@@ -33,6 +33,8 @@ var (
 		"/metadata/uid",
 		"/imagePullSecrets",
 		"/secrets",
+		"/spec/selector/matchLabels/controller-uid",
+		"/spec/template/metadata/labels/controller-uid",
 	}
 	platformManagedRegexFields = []string{
 		"^/spec/triggers/[0-9]*/imageChangeParams/lastTriggeredImage",


### PR DESCRIPTION
Without this, I see this when comparing:
```
~ job/foobar to update
--- Current State (OpenShift cluster)
+++ Desired State (Processed template)
@@ -12,12 +12,10 @@
   parallelism: 1
   selector:
     matchLabels:
-      controller-uid: e383aeef-d31f-11ea-a8a2-0aad3152d0e6
       job-name: foobar
   template:
     metadata:
       labels:
-        controller-uid: e383aeef-d31f-11ea-a8a2-0aad3152d0e6
         job-name: foobar
       name: foobar
     spec:

Summary: 0 in sync, 0 to create, 1 to update, 0 to delete
```