### PR TITLE
Prevent deletion of resources by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ param BAZ=qux
 
 bc,is,dc,svc
 ```
-Please note that boolean flags need to be specified with a value, e.g. `upsert-only true`.
+Please note that boolean flags need to be specified with a value, e.g. `allow-deletion true`.
 
 Tailor will automatically pick up any file named `Tailorfile.<namespace>` or `Tailorfile` in the working directory. Alternatively, a specific file can be selected via `tailor -f somefile`.
 

--- a/cmd/tailor/main.go
+++ b/cmd/tailor/main.go
@@ -111,9 +111,9 @@ var (
 		"ignore-unknown-parameters",
 		"If true, will not stop processing if a provided parameter does not exist in the template.",
 	).Bool()
-	diffUpsertOnlyFlag = diffCommand.Flag(
-		"upsert-only",
-		"Don't delete resource, only create / update.",
+	diffAllowDeletionFlag = diffCommand.Flag(
+		"allow-deletion",
+		"Allow deletion of resource as well.",
 	).Short('u').Bool()
 	diffAllowRecreateFlag = diffCommand.Flag(
 		"allow-recreate",
@@ -159,9 +159,9 @@ var (
 		"ignore-unknown-parameters",
 		"If true, will not stop processing if a provided parameter does not exist in the template.",
 	).Bool()
-	applyUpsertOnlyFlag = applyCommand.Flag(
-		"upsert-only",
-		"Don't delete resource, only create / apply.",
+	applyAllowDeletionFlag = applyCommand.Flag(
+		"allow-deletion",
+		"Allow deletion of resource as well.",
 	).Short('u').Bool()
 	applyAllowRecreateFlag = applyCommand.Flag(
 		"allow-recreate",
@@ -362,7 +362,7 @@ func main() {
 			preservePathFlag,
 			*diffPreserveImmutableFieldsFlag,
 			*diffIgnoreUnknownParametersFlag,
-			*diffUpsertOnlyFlag,
+			*diffAllowDeletionFlag,
 			*diffAllowRecreateFlag,
 			*diffRevealSecretsFlag,
 			false, // verification only when changes are applied
@@ -399,7 +399,7 @@ func main() {
 			preservePathFlag,
 			*applyPreserveImmutableFieldsFlag,
 			*applyIgnoreUnknownParametersFlag,
-			*applyUpsertOnlyFlag,
+			*applyAllowDeletionFlag,
 			*applyAllowRecreateFlag,
 			*applyRevealSecretsFlag,
 			*applyVerifyFlag,

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -46,7 +46,7 @@ type CompareOptions struct {
 	PreservePaths           []string
 	PreserveImmutableFields bool
 	IgnoreUnknownParameters bool
-	UpsertOnly              bool
+	AllowDeletion           bool
 	AllowRecreate           bool
 	RevealSecrets           bool
 	Verify                  bool
@@ -159,7 +159,7 @@ func NewCompareOptions(
 	preserveFlag []string,
 	preserveImmutableFieldsFlag bool,
 	ignoreUnknownParametersFlag bool,
-	upsertOnlyFlag bool,
+	allowDeletionFlag bool,
 	allowRecreateFlag bool,
 	revealSecretsFlag bool,
 	verifyFlag bool,
@@ -284,10 +284,10 @@ func NewCompareOptions(
 		o.IgnoreUnknownParameters = true
 	}
 
-	if upsertOnlyFlag {
-		o.UpsertOnly = true
-	} else if fileFlags["upsert-only"] == "true" {
-		o.UpsertOnly = true
+	if allowDeletionFlag {
+		o.AllowDeletion = true
+	} else if fileFlags["allow-deletion"] == "true" {
+		o.AllowDeletion = true
 	}
 
 	if allowRecreateFlag {

--- a/pkg/commands/diff.go
+++ b/pkg/commands/diff.go
@@ -136,7 +136,7 @@ func calculateChangeset(w io.Writer, compareOptions *cli.CompareOptions, ocClien
 		w,
 		platformBasedList,
 		templateBasedList,
-		compareOptions.UpsertOnly,
+		compareOptions.AllowDeletion,
 		compareOptions.AllowRecreate,
 		compareOptions.RevealSecrets,
 		compareOptions.PathsToPreserve(),
@@ -148,8 +148,8 @@ func calculateChangeset(w io.Writer, compareOptions *cli.CompareOptions, ocClien
 	return updateRequired, changeset, nil
 }
 
-func compare(w io.Writer, remoteResourceList *openshift.ResourceList, localResourceList *openshift.ResourceList, upsertOnly bool, allowRecreate bool, revealSecrets bool, preservePaths []string) (*openshift.Changeset, error) {
-	changeset, err := openshift.NewChangeset(remoteResourceList, localResourceList, upsertOnly, allowRecreate, preservePaths)
+func compare(w io.Writer, remoteResourceList *openshift.ResourceList, localResourceList *openshift.ResourceList, allowDeletion bool, allowRecreate bool, revealSecrets bool, preservePaths []string) (*openshift.Changeset, error) {
+	changeset, err := openshift.NewChangeset(remoteResourceList, localResourceList, allowDeletion, allowRecreate, preservePaths)
 	if err != nil {
 		return changeset, err
 	}

--- a/pkg/openshift/changeset.go
+++ b/pkg/openshift/changeset.go
@@ -40,7 +40,7 @@ type Changeset struct {
 	Noop   []*Change
 }
 
-func NewChangeset(platformBasedList, templateBasedList *ResourceList, upsertOnly bool, allowRecreate bool, preservePaths []string) (*Changeset, error) {
+func NewChangeset(platformBasedList, templateBasedList *ResourceList, allowDeletion bool, allowRecreate bool, preservePaths []string) (*Changeset, error) {
 	changeset := &Changeset{
 		Create: []*Change{},
 		Delete: []*Change{},
@@ -49,7 +49,7 @@ func NewChangeset(platformBasedList, templateBasedList *ResourceList, upsertOnly
 	}
 
 	// items to delete
-	if !upsertOnly {
+	if allowDeletion {
 		for _, item := range platformBasedList.Items {
 			if _, err := templateBasedList.getItem(item.Kind, item.Name); err != nil {
 				change := &Change{


### PR DESCRIPTION
Relates to #240.

Previously this is opt-in via `--upsert-only`, now the behaviour of
"upsert only" would be the default, and you'd need to opt-in to deleting
resources.

This seems like the default I should have chosen in the beginning.

There are some consequences from this change:
* it's breaking and therefore should lead to a new major version (v2)
* it probably replaces the need for `--allow-recreate`

Thoughts @mjfernandezd, @henrjk?