### PR TITLE
Preserve svc cluster ips by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Avoid panic on template with empty parameters([#238](https://github.com/opendevstack/tailor/pull/238))
+- Preserve svc cluster ips by default ([#242](https://github.com/opendevstack/tailor/pull/242))
 
 ## [1.3.1] - 2021-02-11
 

--- a/cmd/tailor/main.go
+++ b/cmd/tailor/main.go
@@ -102,7 +102,7 @@ var (
 	diffPreservePathFlag = diffCommand.Flag(
 		"preserve",
 		"Path(s) per kind/name for which to preserve current state (e.g. because they are externally modified) in RFC 6901 format.",
-	).Default("svc:/spec/clusterIPs").PlaceHolder("bc:foobar:/spec/output/to/name").Strings()
+	).PlaceHolder("bc:foobar:/spec/output/to/name").Strings()
 	diffPreserveImmutableFieldsFlag = diffCommand.Flag(
 		"preserve-immutable-fields",
 		"Preserve current state of all immutable fields (such as host of a route, or storageClassName of a PVC).",

--- a/cmd/tailor/main.go
+++ b/cmd/tailor/main.go
@@ -102,7 +102,7 @@ var (
 	diffPreservePathFlag = diffCommand.Flag(
 		"preserve",
 		"Path(s) per kind/name for which to preserve current state (e.g. because they are externally modified) in RFC 6901 format.",
-	).PlaceHolder("bc:foobar:/spec/output/to/name").Strings()
+	).Default("svc:/spec/clusterIPs").PlaceHolder("bc:foobar:/spec/output/to/name").Strings()
 	diffPreserveImmutableFieldsFlag = diffCommand.Flag(
 		"preserve-immutable-fields",
 		"Preserve current state of all immutable fields (such as host of a route, or storageClassName of a PVC).",

--- a/pkg/openshift/item.go
+++ b/pkg/openshift/item.go
@@ -26,6 +26,7 @@ var (
 		"/metadata/selfLink",
 		"/metadata/uid",
 		"/secrets",
+		"/spec/clusterIP",
 		"/spec/clusterIPs",
 		"/spec/jobTemplate/metadata/creationTimestamp",
 		"/spec/jobTemplate/spec/template/metadata/creationTimestamp",

--- a/pkg/openshift/item.go
+++ b/pkg/openshift/item.go
@@ -26,7 +26,7 @@ var (
 		"/metadata/selfLink",
 		"/metadata/uid",
 		"/secrets",
-		"/spec/clusterIP",
+		"/spec/clusterIPs",
 		"/spec/jobTemplate/metadata/creationTimestamp",
 		"/spec/jobTemplate/spec/template/metadata/creationTimestamp",
 		"/spec/selector/matchLabels/controller-uid",


### PR DESCRIPTION
Note that I haven't added any extra e2e tests covering this feature given that Github Actions spins up an OpenShift 3 cluster and this is a fix for an OpenShift 4.7+ cluster.